### PR TITLE
Add DB models and tests, POST for newdle creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ build/
 .cache/
 pip-wheel-metadata/
 
+# Tests
+.coverage
+htmlcov/
+
 # JS
 /package-lock.json
 node_modules/

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+from newdle.core.app import create_app
+from newdle.core.db import db
+
+
+TEST_DATABASE_URI = 'postgresql:///newdle_tests'
+
+
+@pytest.fixture(scope='session')
+def app(request):
+    """Session-wide test `Flask` application."""
+    config_override = {'TESTING': True, 'SQLALCHEMY_DATABASE_URI': TEST_DATABASE_URI}
+    app = create_app(config_override, use_env_config=False)
+    ctx = app.app_context()
+    ctx.push()
+    yield app
+    ctx.pop()
+
+
+@pytest.fixture(scope='function')
+def db_session(app, request):
+    """Create a new database session."""
+    connection = db.engine.connect()
+    transaction = connection.begin()
+
+    options = dict(bind=connection, binds={})
+    session = db.create_scoped_session(options=options)
+
+    db.session = session
+    db.app = app
+    db.create_all()
+
+    def teardown():
+        transaction.rollback()
+        connection.close()
+        session.remove()
+
+    request.addfinalizer(teardown)
+    return session

--- a/newdle/core/app.py
+++ b/newdle/core/app.py
@@ -9,10 +9,11 @@ from .db import db
 from .marshmallow import mm
 
 
-def _configure_app(app):
+def _configure_app(app, from_env=True):
     app.config.setdefault('PROXY', False)
     app.config.from_pyfile('newdle.cfg.example')
-    app.config.from_envvar('NEWDLE_CONFIG')
+    if from_env:
+        app.config.from_envvar('NEWDLE_CONFIG')
     if app.config['PROXY']:
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
@@ -49,9 +50,11 @@ def _configure_errors(app):
         return jsonify(error='internal_error'), 500
 
 
-def create_app():
+def create_app(config_override=None, use_env_config=True):
     app = Flask('newdle')
-    _configure_app(app)
+    _configure_app(app, from_env=use_env_config)
+    if config_override:
+        app.config.update(config_override)
     _configure_db(app)
     _configure_errors(app)
     mm.init_app(app)

--- a/newdle/core/util.py
+++ b/newdle/core/util.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytz
+from sqlalchemy import func, types
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.sqltypes import Interval
+from sqlalchemy.util import memoized_property
+
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
+
+
+class UTCDateTime(types.TypeDecorator):
+    impl = types.DateTime
+
+    class Comparator(types.DateTime.Comparator):
+        def astimezone(self, tz):
+            """Convert the datetime to a specific timezone.
+            This is useful if you want e.g. to cast to Date afterwards
+            but need a specific timezone instead of UTC.
+            When accessing the value returned by this method in Python
+            it will be a naive datetime object in the specified time
+            zone.
+            :param tz: A timezone name or tzinfo object.
+            """
+            tz = getattr(tz, 'zone', tz)
+            return func.timezone(tz, func.timezone('UTC', self.expr))
+
+    comparator_factory = Comparator
+
+    @memoized_property
+    def _expression_adaptations(self):
+        # this ensures that `UTCDateTime + Interval` returns another
+        # `UTCDateTime` and not just a `DateTime`
+        return {
+            operators.add: {Interval: UTCDateTime},
+            operators.sub: {Interval: UTCDateTime, UTCDateTime: Interval},
+        }
+
+    def process_bind_param(self, value, engine):
+        if value is not None:
+            return value.astimezone(pytz.utc).replace(tzinfo=None)
+
+    def process_result_value(self, value, engine):
+        if value is not None:
+            return value.replace(tzinfo=pytz.utc)
+
+    def alembic_render_type(self, autogen_context):
+        autogen_context.imports.add('from newdle.core.util import UTCDateTime')
+        return type(self).__name__
+
+
+def parse_dt(text):
+    return datetime.strptime(text, DATETIME_FORMAT)
+
+
+def format_dt(dt):
+    return dt.strftime(DATETIME_FORMAT)

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -1,0 +1,76 @@
+from pytz import timezone, utc
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.schema import CheckConstraint
+
+from newdle.core.db import db
+from newdle.core.util import UTCDateTime, format_dt, parse_dt
+
+
+class Newdle(db.Model):
+    __tablename__ = 'newdles'
+
+    id = db.Column(db.Integer, primary_key=True)
+    creator_uid = db.Column(db.String, nullable=False, index=True)
+    title = db.Column(db.String, nullable=False)
+    duration = db.Column(db.Integer, nullable=False)
+    _timezone = db.Column('timezone', db.String, nullable=False)
+    _time_slots = db.Column('time_slots', JSONB, nullable=False)
+    final_dt = db.Column(UTCDateTime, nullable=True)
+
+    participants = db.relationship(
+        'Participant', lazy=True, collection_class=set, back_populates="newdle"
+    )
+
+    @property
+    def timezone(self):
+        return timezone(self._timezone)
+
+    @timezone.setter
+    def timezone(self, value):
+        self._timezone = value
+
+    @property
+    def time_slots(self):
+        return [
+            {
+                'start': parse_dt(ts['start']).astimezone(utc),
+                'end': parse_dt(ts['end']).astimezone(utc),
+            }
+            for ts in self._time_slots
+        ]
+
+    @time_slots.setter
+    def time_slots(self, value):
+        self._time_slots = [
+            {
+                'start': format_dt(ts['start'].astimezone(self.timezone)),
+                'end': format_dt(ts['end'].astimezone(self.timezone)),
+            }
+            for ts in value
+        ]
+
+    def __repr__(self):
+        return "<Newdle {} {}>".format(self.id, 'F' if self.final_dt else '')
+
+
+class Participant(db.Model):
+    __tablename__ = 'participants'
+    __table_args__ = (
+        CheckConstraint('(email IS NULL) = (auth_uid IS NULL)', 'email_uid_null'),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    auth_uid = db.Column(db.String, nullable=True)
+    name = db.Column(db.String, nullable=False)
+    email = db.Column(db.String, nullable=True)
+    answers = db.Column(JSONB, nullable=True)
+    newdle_id = db.Column(
+        db.Integer, db.ForeignKey('newdles.id'), nullable=False, index=True
+    )
+
+    newdle = db.relationship('Newdle', lazy=True, back_populates="participants")
+
+    def __repr__(self):
+        return "<Participant {}: {}{}>".format(
+            self.id, self.name, ' ({})'.format(self.email) if self.email else ''
+        )

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -1,6 +1,8 @@
 from marshmallow import fields, post_dump
+from pytz import common_timezones_set
 
 from .core.marshmallow import mm
+from .core.util import DATETIME_FORMAT
 
 
 class UserSchema(mm.Schema):
@@ -19,3 +21,28 @@ class UserSearchResultSchema(UserSchema):
         if many:
             data = sorted(data, key=lambda x: x['name'].lower())
         return data
+
+
+class ParticipantSchema(mm.Schema):
+    name = fields.String(required=True)
+    email = fields.String()
+    auth_uid = fields.String()
+
+
+class SlotSchema(mm.Schema):
+    start = fields.DateTime(required=True, format=DATETIME_FORMAT)
+    end = fields.DateTime(required=True, format=DATETIME_FORMAT)
+
+
+class NewNewdleSchema(mm.Schema):
+    title = fields.String(validate=lambda x: len(x) >= 3, required=True)
+    duration = fields.Int(required=True, validate=lambda x: x % 15 == 0)
+    timezone = fields.String(
+        validate=lambda x: x in common_timezones_set, required=True
+    )
+    time_slots = fields.List(fields.Nested(SlotSchema), validate=bool, required=True)
+    participants = fields.List(fields.Nested(ParticipantSchema), missing=[])
+
+
+class NewdleSchema(NewNewdleSchema):
+    id = fields.Integer()

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ norecursedirs =
     .*
     .venv
     node_modules
+    newdle/client
 addopts = -rsfEw --cov newdle --cov-report html --no-cov-on-fail -p no:warnings
 python_files = *_test.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+norecursedirs =
+    .*
+    .venv
+    node_modules
+addopts = -rsfEw --cov newdle --cov-report html --no-cov-on-fail -p no:warnings
+python_files = *_test.py

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,5 @@ black
 wheel
 flask-shell-ipython
 ipython
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ marshmallow==3.0.0rc8
 marshmallow-sqlalchemy==0.17.0
 faker==2.0.0
 webargs==5.4.0
+pytz==2019.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ marshmallow==3.0.0rc8
 marshmallow-sqlalchemy==0.17.0
 faker==2.0.0
 webargs==5.4.0
-pytz==2019.2
+pytz

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+import pytest
+from pytz import timezone, utc
+
+from newdle.models import Newdle, Participant
+
+
+@pytest.fixture
+def dummy_newdle(db_session):
+    newdle = Newdle(title='Test event', creator_uid='foo1234', duration=30, timezone='Europe/Zurich', time_slots=[])
+    db_session.add(newdle)
+    db_session.flush()
+    return newdle
+
+
+def test_create_newdle(dummy_newdle):
+    newdle = Newdle.query.get(dummy_newdle.id)
+    assert newdle.final_dt == None
+
+
+def test_set_newdle_final(dummy_newdle, db_session):
+    newdle = Newdle.query.get(dummy_newdle.id)
+    local_tz = timezone('Europe/Zurich')
+    newdle.final_dt = local_tz.localize(datetime(2020, 1, 1, 10, 0, 0))
+    db_session.flush()
+
+    # let's also check that the timezones work well
+    assert newdle.final_dt == utc.localize(datetime(2020, 1, 1, 9, 0, 0))
+
+
+def test_create_participant(dummy_newdle, db_session):
+    participant = Participant(name='John Doe', newdle=dummy_newdle)
+    db_session.add(participant)
+    db_session.flush()
+
+    participant = Participant.query.get(participant.id)
+    assert participant.newdle == dummy_newdle
+    assert dummy_newdle.participants == {participant}
+
+
+def test_newdle_time_slots(dummy_newdle, db_session):
+    dummy_newdle.time_slots = [{
+        'start': utc.localize(datetime(2012, 11, 20, 10, 00)),
+        'end': timezone('Europe/Zurich').localize(datetime(2012, 11, 20, 12, 00))
+    }]
+    db_session.flush()
+
+    newdle = Newdle.query.get(dummy_newdle.id)
+    assert newdle.time_slots == [{
+        'start': utc.localize(datetime(2012, 11, 20, 10, 00)),
+        'end': utc.localize(datetime(2012, 11, 20, 11, 00))
+    }]
+
+def test_participant_email_uid(dummy_newdle, db_session):
+    participant = Participant(name='John Doe', email='john@example.com', auth_uid='john', newdle=dummy_newdle)
+    db_session.add(participant)
+    db_session.flush()
+
+    participant = Participant(name='Paul Doe', newdle=dummy_newdle)
+    db_session.add(participant)
+    db_session.flush()
+
+    participant = Participant(name='Jane Doe', auth_uid='jane', newdle=dummy_newdle)
+    db_session.add(participant)
+    with pytest.raises(Exception) as e:
+        db_session.flush()
+    assert 'violates check constraint' in str(e.value)


### PR DESCRIPTION
This closes #19 and #22 and adds as well the possibility to create Python unit tests.

When it comes to testing, you should have an empty `newdle_tests` DB in your machine. It would be great if we could reuse https://github.com/indico/indico/blob/master/indico/testing/fixtures/database.py and https://github.com/indico/indico/blob/master/indico/core/db/sqlalchemy/util/management.py, maybe moving them to a 3rd party lib?