### PR TITLE
Reset creation state when leaving /new & prompt before losing data

### DIFF
--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -7,6 +7,7 @@ export const USER_RECEIVED = 'User info received';
 export const TOKEN_EXPIRED = 'Expired token needs refresh';
 export const SET_ACTIVE_DATE = 'Change selected date';
 export const SET_STEP = 'Change Newdle creation step';
+export const ABORT_CREATION = 'Abort Newdle creation';
 export const ADD_PARTICIPANTS = 'Add new participants';
 export const REMOVE_PARTICIPANT = 'Remove a participant';
 export const SET_DURATION = 'Set meeting duration';
@@ -45,6 +46,10 @@ export function setActiveDate(date) {
 
 export function setStep(step) {
   return {type: SET_STEP, step};
+}
+
+export function abortCreation() {
+  return {type: ABORT_CREATION};
 }
 
 export function addParticipants(participants) {

--- a/newdle/client/src/components/CreateNewdle.js
+++ b/newdle/client/src/components/CreateNewdle.js
@@ -1,15 +1,22 @@
 import React, {useEffect} from 'react';
 import {Button, Container, Grid, Icon} from 'semantic-ui-react';
 import {useDispatch, useSelector} from 'react-redux';
-import {getStep, areParticipantsDefined, getMeetingParticipants} from '../selectors';
+import {
+  getStep,
+  areParticipantsDefined,
+  getMeetingParticipants,
+  shouldConfirmAbortCreation,
+} from '../selectors';
 import {abortCreation, setStep} from '../actions';
 import Calendar from './Calendar';
 import Availability from './Availability';
 import UserSearch from './UserSearch';
+import UnloadPrompt from './UnloadPrompt';
 import styles from './CreateNewdle.module.scss';
 
 export default function CreateNewdle() {
   const step = useSelector(getStep);
+  const shouldConfirm = useSelector(shouldConfirmAbortCreation);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -33,6 +40,7 @@ export default function CreateNewdle() {
           </div>
         </div>
       )}
+      <UnloadPrompt router active={shouldConfirm} />>
     </>
   );
 }

--- a/newdle/client/src/components/CreateNewdle.js
+++ b/newdle/client/src/components/CreateNewdle.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Button, Container, Grid, Icon} from 'semantic-ui-react';
 import {useDispatch, useSelector} from 'react-redux';
 import {getStep, areParticipantsDefined, getMeetingParticipants} from '../selectors';
-import {setStep} from '../actions';
+import {abortCreation, setStep} from '../actions';
 import Calendar from './Calendar';
 import Availability from './Availability';
 import UserSearch from './UserSearch';
@@ -11,6 +11,13 @@ import styles from './CreateNewdle.module.scss';
 export default function CreateNewdle() {
   const step = useSelector(getStep);
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    return () => {
+      dispatch(abortCreation());
+    };
+  }, [dispatch]);
+
   return (
     <>
       {step === 1 && <ParticipantsPage />}

--- a/newdle/client/src/components/UnloadPrompt.js
+++ b/newdle/client/src/components/UnloadPrompt.js
@@ -1,0 +1,40 @@
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {Prompt} from 'react-router';
+
+function UnloadPrompt({active, router, message}) {
+  if (!message) {
+    message = 'Are you sure you want to leave this page without saving?';
+  }
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const onBeforeUnload = evt => {
+      evt.preventDefault();
+      evt.returnValue = message;
+    };
+
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, [active, message]);
+
+  return router ? <Prompt when={active} message={message} /> : null;
+}
+
+UnloadPrompt.propTypes = {
+  active: PropTypes.bool.isRequired,
+  router: PropTypes.bool,
+  message: PropTypes.string,
+};
+
+UnloadPrompt.defaultProps = {
+  message: null,
+  router: true,
+};
+
+export default React.memo(UnloadPrompt);

--- a/newdle/client/src/reducers.js
+++ b/newdle/client/src/reducers.js
@@ -7,6 +7,7 @@ import {
   USER_RECEIVED,
   SET_ACTIVE_DATE,
   SET_STEP,
+  ABORT_CREATION,
   ADD_PARTICIPANTS,
   REMOVE_PARTICIPANT,
   SET_DURATION,
@@ -53,6 +54,8 @@ export default combineReducers({
       switch (action.type) {
         case SET_STEP:
           return null;
+        case ABORT_CREATION:
+          return null;
         case SET_ACTIVE_DATE:
           return action.date;
         default:
@@ -62,6 +65,8 @@ export default combineReducers({
   }),
   timeslots: (state = {}, action) => {
     switch (action.type) {
+      case ABORT_CREATION:
+        return {};
       case ADD_TIMESLOT:
         return {...state, [action.date]: [...(state[action.date] || []), action.time]};
       case REMOVE_TIMESLOT: {
@@ -79,6 +84,8 @@ export default combineReducers({
   },
   step: (state = 1, action) => {
     switch (action.type) {
+      case ABORT_CREATION:
+        return 1;
       case SET_STEP:
         return action.step;
       default:
@@ -87,6 +94,8 @@ export default combineReducers({
   },
   participants: (state = [], action) => {
     switch (action.type) {
+      case ABORT_CREATION:
+        return [];
       case ADD_PARTICIPANTS:
         return [...state, ...action.participants];
       case REMOVE_PARTICIPANT:
@@ -98,6 +107,8 @@ export default combineReducers({
 
   duration: (state = 15, action) => {
     switch (action.type) {
+      case ABORT_CREATION:
+        return 15;
       case SET_DURATION:
         return action.duration;
       default:

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -18,3 +18,8 @@ export const getStep = state => state.step;
 export const getMeetingParticipants = state => state.participants;
 export const areParticipantsDefined = state => state.participants.length !== 0;
 export const getDuration = state => state.duration;
+export const shouldConfirmAbortCreation = createSelector(
+  _getAllTimeslots,
+  areParticipantsDefined,
+  (timeslots, hasParticipants) => Object.keys(timeslots).length || hasParticipants
+);


### PR DESCRIPTION
Navigating away from the Newdle creation page now resets all creation-related data in the state. If the user made any meaningful changes (anything except duration for now), they are also prompted to confirm before navigating away.

closes #52