### PR TITLE
Fix token refresh for concurrent requests & requests where no token is present

### DIFF
--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -3,10 +3,12 @@ import client from './client';
 
 export const LOGIN_WINDOW_OPENED = 'Login window opened';
 export const LOGIN_WINDOW_CLOSED = 'Login window closed';
+export const LOGIN_PROMPT_ABORTED = 'User refused to login';
 export const USER_LOGIN = 'User logged in';
 export const USER_LOGOUT = 'User logged out';
 export const USER_RECEIVED = 'User info received';
 export const TOKEN_EXPIRED = 'Expired token needs refresh';
+export const TOKEN_NEEDED = 'Login required to send request';
 export const SET_ACTIVE_DATE = 'Change selected date';
 export const SET_STEP = 'Change Newdle creation step';
 export const ABORT_CREATION = 'Abort Newdle creation';
@@ -27,6 +29,10 @@ export function loginWindowOpened(id) {
 
 export function loginWindowClosed() {
   return {type: LOGIN_WINDOW_CLOSED};
+}
+
+export function loginPromptAborted() {
+  return {type: LOGIN_PROMPT_ABORTED};
 }
 
 export function userLogin(token) {
@@ -53,6 +59,10 @@ export function loadUser() {
 
 export function tokenExpired() {
   return {type: TOKEN_EXPIRED};
+}
+
+export function tokenNeeded() {
+  return {type: TOKEN_NEEDED};
 }
 
 export function setActiveDate(date) {

--- a/newdle/client/src/auth.js
+++ b/newdle/client/src/auth.js
@@ -2,13 +2,14 @@ import {useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import flask from 'flask-urls.macro';
 import {userLogout, userLogin, loginWindowOpened, loginWindowClosed} from './actions';
-import {getToken, getLoginWindowId, isLoggedIn} from './selectors';
+import {getToken, getLoginWindowId, isLoggedIn, isRefreshingToken} from './selectors';
 
 export function useAuthentication() {
   const popup = useRef(null);
   const popupId = useRef(null);
   const loginWindowId = useSelector(getLoginWindowId);
   const isUserLoggedIn = useSelector(isLoggedIn);
+  const refreshing = useSelector(isRefreshingToken);
   const dispatch = useDispatch();
 
   const login = () => {
@@ -70,7 +71,7 @@ export function useAuthentication() {
   }, [dispatch]);
 
   useEffect(() => {
-    if (isUserLoggedIn) {
+    if (isUserLoggedIn && !refreshing) {
       return;
     }
     const interval = window.setInterval(() => {
@@ -86,7 +87,7 @@ export function useAuthentication() {
     return () => {
       window.clearInterval(interval);
     };
-  }, [dispatch, loginWindowId, isUserLoggedIn]);
+  }, [dispatch, loginWindowId, isUserLoggedIn, refreshing]);
 
   return {login, logout};
 }

--- a/newdle/client/src/auth.js
+++ b/newdle/client/src/auth.js
@@ -2,14 +2,14 @@ import {useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import flask from 'flask-urls.macro';
 import {userLogout, userLogin, loginWindowOpened, loginWindowClosed} from './actions';
-import {getToken, getLoginWindowId, isLoggedIn, isRefreshingToken} from './selectors';
+import {getToken, getLoginWindowId, isLoggedIn, isAcquiringToken} from './selectors';
 
 export function useAuthentication() {
   const popup = useRef(null);
   const popupId = useRef(null);
   const loginWindowId = useSelector(getLoginWindowId);
   const isUserLoggedIn = useSelector(isLoggedIn);
-  const refreshing = useSelector(isRefreshingToken);
+  const acquiringToken = useSelector(isAcquiringToken);
   const dispatch = useDispatch();
 
   const login = () => {
@@ -71,7 +71,7 @@ export function useAuthentication() {
   }, [dispatch]);
 
   useEffect(() => {
-    if (isUserLoggedIn && !refreshing) {
+    if (isUserLoggedIn && !acquiringToken) {
       return;
     }
     const interval = window.setInterval(() => {
@@ -87,7 +87,7 @@ export function useAuthentication() {
     return () => {
       window.clearInterval(interval);
     };
-  }, [dispatch, loginWindowId, isUserLoggedIn, refreshing]);
+  }, [dispatch, loginWindowId, isUserLoggedIn, acquiringToken]);
 
   return {login, logout};
 }

--- a/newdle/client/src/components/App.js
+++ b/newdle/client/src/components/App.js
@@ -1,20 +1,17 @@
 import React from 'react';
 import {useSelector} from 'react-redux';
-import {Modal} from 'semantic-ui-react';
 import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
 import Home from './Home';
 import CreateNewdle from './CreateNewdle';
-import {isLoginWindowOpen, isRefreshingToken} from '../selectors';
-import {useAuthentication} from '../auth';
+import {isLoginWindowOpen} from '../selectors';
 import TopHeader from './TopHeader';
 import NewdleCreated from './NewdleCreated';
+import LoginPrompt from './LoginPrompt';
 import LoggingIn from './LoggingIn';
 import './App.module.scss';
 
 export default function App() {
   const loggingIn = useSelector(isLoginWindowOpen);
-  const refreshing = useSelector(isRefreshingToken);
-  const {login, logout} = useAuthentication();
 
   return (
     <Router>
@@ -26,18 +23,7 @@ export default function App() {
           <Route exact path="/new/success" component={NewdleCreated} />
           <Route render={() => 'This page does not exist'} />
         </Switch>
-        {refreshing && (
-          <Modal
-            open
-            size="mini"
-            header="Your session expired"
-            content="Please log in again to confirm your identity"
-            actions={[
-              {key: 'login', content: 'Login', positive: true, onClick: login},
-              {key: 'logout', content: 'Logout', onClick: logout},
-            ]}
-          />
-        )}
+        <LoginPrompt />
         {loggingIn && <LoggingIn />}
       </main>
     </Router>

--- a/newdle/client/src/components/LoginPrompt.js
+++ b/newdle/client/src/components/LoginPrompt.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import {Modal} from 'semantic-ui-react';
+import {useDispatch, useSelector} from 'react-redux';
+import {isAcquiringToken, isLoggedIn} from '../selectors';
+import {useAuthentication} from '../auth';
+import {useRouter} from '../util/router';
+import {loginPromptAborted} from '../actions';
+
+export default function LoginPrompt() {
+  const acquiringToken = useSelector(isAcquiringToken);
+  const loggedIn = useSelector(isLoggedIn);
+  const {login, logout} = useAuthentication();
+  const router = useRouter();
+  const dispatch = useDispatch();
+
+  if (!acquiringToken) {
+    return null;
+  } else if (loggedIn) {
+    // refreshing expired token
+    return (
+      <Modal
+        open
+        size="mini"
+        header="Your session expired"
+        content="Please log in again to confirm your identity"
+        actions={[
+          {key: 'login', content: 'Login', positive: true, onClick: login},
+          {key: 'logout', content: 'Logout', onClick: logout},
+        ]}
+      />
+    );
+  } else {
+    // (fresh) login required
+    return (
+      <Modal
+        open
+        size="mini"
+        header="Login required"
+        content="You need to log in to access this page"
+        actions={[
+          {key: 'login', content: 'Login', positive: true, onClick: login},
+          {
+            key: 'cancel',
+            content: 'Cancel',
+            onClick: () => {
+              router.history.push('/');
+              dispatch(loginPromptAborted());
+            },
+          },
+        ]}
+      />
+    );
+  }
+}

--- a/newdle/client/src/reducers.js
+++ b/newdle/client/src/reducers.js
@@ -5,8 +5,10 @@ import 'moment-timezone';
 import {combineReducers} from 'redux';
 import {
   TOKEN_EXPIRED,
+  TOKEN_NEEDED,
   LOGIN_WINDOW_OPENED,
   LOGIN_WINDOW_CLOSED,
+  LOGIN_PROMPT_ABORTED,
   USER_LOGIN,
   USER_LOGOUT,
   USER_RECEIVED,
@@ -37,12 +39,14 @@ export default combineReducers({
           return state;
       }
     },
-    refreshing: (state = false, action) => {
+    acquiringToken: (state = false, action) => {
       switch (action.type) {
         case TOKEN_EXPIRED:
+        case TOKEN_NEEDED:
           return true;
         case USER_LOGIN:
         case USER_LOGOUT:
+        case LOGIN_PROMPT_ABORTED:
           return false;
         default:
           return state;

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -6,7 +6,7 @@ export const getToken = state => state.auth.token;
 export const getLoginWindowId = state => state.auth.windowId;
 export const isLoginWindowOpen = state => !!state.auth.windowId;
 export const isLoggedIn = state => !!state.auth.token;
-export const isRefreshingToken = state => !!state.auth.refreshing;
+export const isAcquiringToken = state => !!state.auth.acquiringToken;
 export const getUserInfo = state => state.user;
 export const getCalendarDates = state => Object.keys(state.timeslots);
 export const getCalendarActiveDate = state =>


### PR DESCRIPTION
When not logged-in, a slightly different modal is shown