### PR TITLE
Make "back" buttons nicer

### DIFF
--- a/newdle/client/src/components/CreateNewdle.js
+++ b/newdle/client/src/components/CreateNewdle.js
@@ -59,7 +59,7 @@ function ParticipantsPage() {
         <div className={styles['button-row']}>
           <Button color="violet" icon labelPosition="right" onClick={() => dispatch(setStep(2))}>
             {participantsDefined ? 'Next' : 'Skip'}
-            <Icon name="caret right" />
+            <Icon name="angle right" />
           </Button>
         </div>
       </Container>
@@ -86,7 +86,7 @@ function TimeSlotsPage() {
           <div className={styles['button-row']}>
             <Button color="violet" icon labelPosition="left" onClick={() => dispatch(setStep(1))}>
               Back
-              <Icon name="caret left" />
+              <Icon name="angle left" />
             </Button>
             <Button
               color="violet"
@@ -96,7 +96,7 @@ function TimeSlotsPage() {
               onClick={() => dispatch(setStep(3))}
             >
               Next step
-              <Icon name="caret right" />
+              <Icon name="angle right" />
             </Button>
           </div>
         </Grid.Row>
@@ -182,19 +182,23 @@ function FinalizePage() {
       </div>
       <div className={styles['link-row']}>
         <Button
-          className={styles['link']}
+          size="small"
+          color="violet"
+          basic
           onClick={() => dispatch(setStep(1))}
           disabled={submitting}
-        >
-          Change participants
-        </Button>
+          icon="angle double left"
+          content="Change participants"
+        />
         <Button
-          className={styles['link']}
+          size="small"
+          color="violet"
+          basic
           onClick={() => dispatch(setStep(2))}
           disabled={submitting}
-        >
-          Change time slots
-        </Button>
+          icon="angle double left"
+          content="Change time slots"
+        />
       </div>
     </Container>
   );

--- a/newdle/client/src/components/Home.js
+++ b/newdle/client/src/components/Home.js
@@ -44,7 +44,7 @@ export default function Home() {
             }}
           >
             Get started
-            <Icon name="caret right" />
+            <Icon name="angle right" />
           </LoginRequired>
         </div>
         <div className={styles.footer}>

--- a/newdle/client/src/components/Navigator.js
+++ b/newdle/client/src/components/Navigator.js
@@ -1,9 +1,11 @@
+import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Container} from 'semantic-ui-react';
-import {useSelector} from 'react-redux';
-import {getStep} from '../selectors';
+import {useDispatch, useSelector} from 'react-redux';
+import {getStep, getFullTimeslots} from '../selectors';
 import styles from './Navigator.module.scss';
+import {setStep} from '../actions';
 
 export default function Navigator() {
   const steps = [
@@ -21,12 +23,22 @@ export default function Navigator() {
     },
   ];
   const active = useSelector(getStep);
+  const slots = useSelector(getFullTimeslots);
+  const dispatch = useDispatch();
   const activeStep = steps[active - 1];
 
   return (
     <Container>
-      {steps.map((step, index) => (
-        <Step key={index} active={index + 1 === active}>
+      {steps.map((__, index) => (
+        <Step
+          key={index}
+          index={index + 1}
+          active={index + 1 === active}
+          // Step 3 (index === 2) should only be clickable if there are already slots defined
+          onClick={
+            index !== 2 || !_.isEmpty(slots) ? () => dispatch(setStep(index + 1)) : undefined
+          }
+        >
           {index + 1}
         </Step>
       ))}
@@ -35,20 +47,32 @@ export default function Navigator() {
   );
 }
 
-function Step({active, children}) {
-  return <div className={`${styles.step} ${active ? styles.active : ''}`}>{children}</div>;
+function Step({active, children, onClick}) {
+  return (
+    <div
+      className={`${styles.step} ${active ? styles.active : ''} ${onClick ? styles.clickable : ''}`}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
 }
 
 Step.propTypes = {
   active: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+};
+
+Step.defaultProps = {
+  onClick: () => {},
 };
 
 function StepBody({title, description}) {
   return (
     <div className={styles['step-body']}>
       <h3>{title}</h3>
-      <div className={styles['description']}>{description}</div>
+      <div className={styles.description}>{description}</div>
     </div>
   );
 }

--- a/newdle/client/src/components/Navigator.js
+++ b/newdle/client/src/components/Navigator.js
@@ -29,19 +29,21 @@ export default function Navigator() {
 
   return (
     <Container>
-      {steps.map((__, index) => (
-        <Step
-          key={index}
-          index={index + 1}
-          active={index + 1 === active}
-          // Step 3 (index === 2) should only be clickable if there are already slots defined
-          onClick={
-            index !== 2 || !_.isEmpty(slots) ? () => dispatch(setStep(index + 1)) : undefined
-          }
-        >
-          {index + 1}
-        </Step>
-      ))}
+      <ul className={styles['step-box']}>
+        {steps.map((__, index) => (
+          <Step
+            key={index}
+            index={index + 1}
+            active={index + 1 === active}
+            // Step 3 (index === 2) should only be clickable if there are already slots defined
+            onClick={
+              index !== 2 || !_.isEmpty(slots) ? () => dispatch(setStep(index + 1)) : undefined
+            }
+          >
+            {index + 1}
+          </Step>
+        ))}
+      </ul>
       <StepBody title={activeStep.title} description={activeStep.description} />
     </Container>
   );
@@ -49,12 +51,12 @@ export default function Navigator() {
 
 function Step({active, children, onClick}) {
   return (
-    <div
+    <li
       className={`${styles.step} ${active ? styles.active : ''} ${onClick ? styles.clickable : ''}`}
       onClick={onClick}
     >
       {children}
-    </div>
+    </li>
   );
 }
 

--- a/newdle/client/src/components/Navigator.module.scss
+++ b/newdle/client/src/components/Navigator.module.scss
@@ -1,25 +1,39 @@
 @import '../styles/palette.scss';
 @import '../styles/boxes.scss';
 
+.step-box {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0 0 0.5em 0;
+  display: flex;
+  align-items: flex-end;
+}
+
 .step {
   display: inline-block;
-  min-height: 1em;
-  padding: 0.78em 1em 0.78em;
   margin: 0em 0.25em 0em 0em;
   background: white;
   border: none;
   border-radius: 0;
   color: $pink;
-  transition: background 0.25s ease-in, transform 0.25s ease-in;
+  transition: background 0.25s ease-in, transform 0.25s ease-in, width 0.25s ease-in;
   user-select: none;
+  width: 3em;
+  height: 3em;
+  line-height: 3em;
+  text-align: center;
+  font-size: 1.1em;
 
   &.active {
     background: $purple;
     color: white;
     border: none;
     border-radius: 0;
-    margin-bottom: 5px;
-    transform: translate(0, -5px);
+    transform: translate(0, -0.2em);
+    width: 2.4em;
+    height: 2.4em;
+    line-height: 2.4em;
+    font-size: 1.5em;
   }
 
   &.clickable {

--- a/newdle/client/src/components/Navigator.module.scss
+++ b/newdle/client/src/components/Navigator.module.scss
@@ -11,15 +11,20 @@
   border-radius: 0;
   color: $pink;
   transition: background 0.25s ease-in, transform 0.25s ease-in;
-}
+  user-select: none;
 
-.active {
-  background: $purple;
-  color: white;
-  border: none;
-  border-radius: 0;
-  margin-bottom: 5px;
-  transform: translate(0, -5px);
+  &.active {
+    background: $purple;
+    color: white;
+    border: none;
+    border-radius: 0;
+    margin-bottom: 5px;
+    transform: translate(0, -5px);
+  }
+
+  &.clickable {
+    cursor: pointer;
+  }
 }
 
 .step-body {


### PR DESCRIPTION
The "back" buttons now look nicer:
![image](https://user-images.githubusercontent.com/2699/65953064-7e096f00-e443-11e9-8974-75ee83fc2629.png)

The `Navigator` was also improved. The steps are now clickable:
![image](https://user-images.githubusercontent.com/2699/65953145-a729ff80-e443-11e9-90c3-906062aa767a.png)

Closes #64 