### PR TITLE
Use nicer availability ring in summary

### DIFF
--- a/newdle/client/package-lock.json
+++ b/newdle/client/package-lock.json
@@ -11657,11 +11657,6 @@
         }
       }
     },
-    "react-circular-progressbar": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-circular-progressbar/-/react-circular-progressbar-2.0.2.tgz",
-      "integrity": "sha512-o0xpWnW53LAOmyvk3HpzxcUbysYpOVZJ9sm3kHTLBd10Mryev42eq2Q1UjayaBPkvNHtlcbtjDm4xOCI/4WxQQ=="
-    },
     "react-dates": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.2.1.tgz",

--- a/newdle/client/package.json
+++ b/newdle/client/package.json
@@ -11,7 +11,6 @@
     "moment-timezone": "^0.5.27",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
-    "react-circular-progressbar": "^2.0.2",
     "react-dates": "^21.2.1",
     "react-dom": "^16.10.2",
     "react-final-form": "^6.3.0",

--- a/newdle/client/src/components/AvailabilityRing.js
+++ b/newdle/client/src/components/AvailabilityRing.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function AvailabilityRing({
+  available,
+  ifNeeded,
+  totalParticipants,
+  strokeWidth,
+  radius,
+}) {
+  const size = radius * 1.1;
+  const normalizedRadius = radius - 14;
+  const circumference = normalizedRadius * 2 * Math.PI;
+
+  return (
+    <div>
+      <svg height={size * 2} width={size * 2}>
+        <circle
+          stroke="#00ac46"
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          strokeDasharray={
+            circumference * (available / totalParticipants) +
+            ' ' +
+            circumference * ((totalParticipants - available) / totalParticipants)
+          }
+          transform={`rotate(-90 ${size} ${size})`}
+          r={normalizedRadius}
+          cx={size}
+          cy={size}
+        />
+        <circle
+          stroke="#fdc500"
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference * (ifNeeded / totalParticipants) + ' ' + circumference}
+          transform={`rotate(${-90 + (available / totalParticipants) * 360} ${size} ${size})`}
+          r={normalizedRadius}
+          cx={size}
+          cy={size}
+        />
+        <circle
+          stroke="#dc0000"
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          strokeDasharray={
+            circumference * ((totalParticipants - (available + ifNeeded)) / totalParticipants) +
+            ' ' +
+            circumference
+          }
+          transform={`rotate(${-90 +
+            ((available + ifNeeded) / totalParticipants) * 360} ${size} ${size})`}
+          r={normalizedRadius}
+          cx={size}
+          cy={size}
+        />
+        <text x="50%" y="50%" textAnchor="middle" stroke="#000" strokeWidth=".3px" dy=".3em">
+          {available + '/' + totalParticipants}
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+AvailabilityRing.propTypes = {
+  available: PropTypes.number.isRequired,
+  ifNeeded: PropTypes.number.isRequired,
+  totalParticipants: PropTypes.number.isRequired,
+  strokeWidth: PropTypes.number,
+  radius: PropTypes.number,
+};
+
+AvailabilityRing.defaultProps = {
+  strokeWidth: 10,
+  radius: 50,
+};

--- a/newdle/client/src/components/ParticipantTable.js
+++ b/newdle/client/src/components/ParticipantTable.js
@@ -58,11 +58,7 @@ function ParticipantNames({participants}) {
   }
 }
 
-function AvailabilityRow({
-  availability: {startDt, available, participationCount},
-  setActiveDate,
-  active,
-}) {
+function AvailabilityRow({availability: {startDt, available}, setActiveDate, active}) {
   const numberOfParticipants = useSelector(getNumberOfParticipants);
   const duration = useSelector(getNewdleDuration);
   const startTime = toMoment(startDt, 'YYYY-MM-DDTHH:mm');
@@ -81,8 +77,8 @@ function AvailabilityRow({
         <div className={styles['wrapper']}>
           <div className={styles['availability-indicator']}>
             <AvailabilityRing
-              available={participationCount.available}
-              ifNeeded={participationCount.ifneedbe}
+              available={available.filter(p => p.fullyAvailable).length}
+              ifNeeded={available.filter(p => !p.fullyAvailable).length}
               totalParticipants={numberOfParticipants}
             />
           </div>

--- a/newdle/client/src/components/ParticipantTable.js
+++ b/newdle/client/src/components/ParticipantTable.js
@@ -2,10 +2,9 @@ import React, {useState} from 'react';
 import moment from 'moment';
 import {useSelector} from 'react-redux';
 import {Radio, Icon, Label, Table} from 'semantic-ui-react';
-import {CircularProgressbar, buildStyles} from 'react-circular-progressbar';
+import AvailabilityRing from './AvailabilityRing';
 import {serializeDate, toMoment} from '../util/date';
 import {getNewdleDuration, getNumberOfParticipants, getParticipantAvailability} from '../selectors';
-import 'react-circular-progressbar/dist/styles.css';
 import styles from './ParticipantTable.module.scss';
 
 const MAX_PARTICIPANTS_SHOWN = 4;
@@ -59,7 +58,11 @@ function ParticipantNames({participants}) {
   }
 }
 
-function AvailabilityRow({availability: {startDt, available}, setActiveDate, active}) {
+function AvailabilityRow({
+  availability: {startDt, available, participationCount},
+  setActiveDate,
+  active,
+}) {
   const numberOfParticipants = useSelector(getNumberOfParticipants);
   const duration = useSelector(getNewdleDuration);
   const startTime = toMoment(startDt, 'YYYY-MM-DDTHH:mm');
@@ -77,17 +80,10 @@ function AvailabilityRow({availability: {startDt, available}, setActiveDate, act
       <Table.Cell width={10} className={styles['available-participants']} textAlign="left">
         <div className={styles['wrapper']}>
           <div className={styles['availability-indicator']}>
-            <CircularProgressbar
-              value={available.length}
-              text={`${available.length} / ${numberOfParticipants}`}
-              maxValue={numberOfParticipants}
-              styles={buildStyles({
-                textSize: '18px',
-                strokeLinecap: 'butt',
-                pathColor: numberOfParticipants === 0 ? 'gray' : 'lightgreen',
-                trailColor: 'red',
-                textColor: 'black',
-              })}
+            <AvailabilityRing
+              available={participationCount.available}
+              ifNeeded={participationCount.ifneedbe}
+              totalParticipants={numberOfParticipants}
             />
           </div>
           <div className={styles['participants']}>

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -104,17 +104,10 @@ export const getParticipantAvailability = createSelector(
   getNewdleParticipants,
   (timeslots, participants) => {
     return timeslots.map(timeslot => {
-      let participationCount = {available: 0, ifneedbe: 0};
-      let available = [];
-      participants.forEach(part => {
-        if (part.answers[timeslot] === 'ifneedbe') {
-          participationCount['ifneedbe'] += 1;
-        } else if (part.answers[timeslot] === 'available') {
-          participationCount['available'] += 1;
-          available.push({...part, fullyAvailable: part.answers[timeslot] === 'available'});
-        }
-      });
-      return {startDt: timeslot, available, participationCount};
+      const available = participants
+        .filter(part => ['available', 'ifneedbe'].includes(part.answers[timeslot]))
+        .map(part => ({...part, fullyAvailable: part.answers[timeslot] === 'available'}));
+      return {startDt: timeslot, available};
     });
   }
 );

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -104,10 +104,17 @@ export const getParticipantAvailability = createSelector(
   getNewdleParticipants,
   (timeslots, participants) => {
     return timeslots.map(timeslot => {
-      const available = participants
-        .filter(part => ['available', 'ifneedbe'].includes(part.answers[timeslot]))
-        .map(part => ({...part, fullyAvailable: part.answers[timeslot] === 'available'}));
-      return {startDt: timeslot, available};
+      let participationCount = {available: 0, ifneedbe: 0};
+      let available = [];
+      participants.forEach(part => {
+        if (part.answers[timeslot] === 'ifneedbe') {
+          participationCount['ifneedbe'] += 1;
+        } else if (part.answers[timeslot] === 'available') {
+          participationCount['available'] += 1;
+          available.push({...part, fullyAvailable: part.answers[timeslot] === 'available'});
+        }
+      });
+      return {startDt: timeslot, available, participationCount};
     });
   }
 );


### PR DESCRIPTION
Replaced `react-circular-progressbar` with AvailabilityRing.js, a component that returns an svg and a counter to show meeting participant status.

AvailabilityRing.js support 3 states (Red, Yellow, Green) and displays a counter (below the ring) for the number of `accepted invitations / total invitations`.

Props include: 
-  available: number of people available
- ifNeeded: number of people available if needed
- totalParticipants: number of people invited
- strokeWidth: width of stroke (optional)
- radius: radius of ring (optional)

Example States:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/15878614/67627031-b0c83c80-f822-11e9-823e-435c71732678.png">

<img width="611" alt="image" src="https://user-images.githubusercontent.com/15878614/67627038-c0e01c00-f822-11e9-83c3-630ac8cba60f.png">

<img width="623" alt="image" src="https://user-images.githubusercontent.com/15878614/67627045-cf2e3800-f822-11e9-836f-0fd6a3dcc1c7.png">

<img width="631" alt="image" src="https://user-images.githubusercontent.com/15878614/67627051-e2d99e80-f822-11e9-98fb-93d5f2887e53.png">

Definitely open to feedback :)

closes #151