### PR TITLE
Fix the handling of timezones in free/busy views

### DIFF
--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -106,11 +106,11 @@ export function removeParticipant(participant) {
   return {type: REMOVE_PARTICIPANT, participant};
 }
 
-export function fetchParticipantBusyTimes(participants, date) {
+export function fetchParticipantBusyTimes(participants, date, tz) {
   return async dispatch => {
     participants.forEach(async participant => {
       dispatch({type: SET_PARTICIPANT_BUSY_TIMES, id: participant.uid, date, times: null});
-      const times = await client.catchErrors(client.getBusyTimes(date, participant.uid));
+      const times = await client.catchErrors(client.getBusyTimes(date, tz, participant.uid));
 
       if (times !== undefined) {
         dispatch({type: SET_PARTICIPANT_BUSY_TIMES, id: participant.uid, date, times});
@@ -186,11 +186,11 @@ export function updateNewdle(newdle) {
   return {type: NEWDLE_UPDATED, newdle};
 }
 
-export function fetchBusyTimesForAnswer(newdleCode, participantCode, dates) {
+export function fetchBusyTimesForAnswer(newdleCode, participantCode, dates, tz) {
   return async dispatch => {
     dates.forEach(async date => {
       const times = await client.catchErrors(
-        client.getBusyTimes(date, null, newdleCode, participantCode)
+        client.getBusyTimes(date, tz, null, newdleCode, participantCode)
       );
 
       if (times !== undefined) {

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -11,6 +11,7 @@ export const getParticipant = state => state.answer.participant;
 export const isParticipantUnknown = state =>
   !state.answer.participant || state.answer.participant.auth_uid === null;
 export const getNewdleDuration = state => state.answer.newdle && state.answer.newdle.duration;
+export const getNewdleTimezone = state => state.answer.newdle && state.answer.newdle.timezone;
 export const getNewdleTimeslots = state =>
   (state.answer.newdle && state.answer.newdle.timeslots) || [];
 export const getNumberOfTimeslots = createSelector(

--- a/newdle/client/src/client.js
+++ b/newdle/client/src/client.js
@@ -141,15 +141,16 @@ class Client {
     return this._request(flask`api.get_my_newdles`());
   }
 
-  getBusyTimes(date, uid, newdleCode = null, participantCode = null) {
+  getBusyTimes(date, tz, uid, newdleCode = null, participantCode = null) {
     if (uid !== null) {
-      return this._request(flask`api.get_busy_times`({date, uid}));
+      return this._request(flask`api.get_busy_times`({date, uid, tz}));
     } else {
       return this._request(
         flask`api.get_participant_busy_times`({
           code: newdleCode,
           participant_code: participantCode || 'me',
           date,
+          tz,
         }),
         {anonymous: participantCode !== null}
       );

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -9,6 +9,7 @@ import FinalDate from '../common/FinalDate';
 import {
   getAnswers,
   getNewdle,
+  getNewdleTimezone,
   getNumberOfAvailableAnswers,
   getNumberOfTimeslots,
   getParticipant,
@@ -85,6 +86,7 @@ export default function AnswerPage() {
   const participantUnknown = useSelector(isParticipantUnknown);
   const participantAnswersChanged = useSelector(haveParticipantAnswersChanged);
   const busyTimesLoaded = useSelector(hasBusyTimes);
+  const tz = useSelector(getNewdleTimezone);
   usePageTitle(newdle && newdle.title, true);
 
   const [submitAnswer, submitting, , submitResult] = participantCode
@@ -129,9 +131,9 @@ export default function AnswerPage() {
 
   useEffect(() => {
     if ((participantCode && !participantUnknown) || (!participantCode && user)) {
-      dispatch(fetchBusyTimesForAnswer(newdleCode, participantCode || null, dates));
+      dispatch(fetchBusyTimesForAnswer(newdleCode, participantCode || null, dates, tz));
     }
-  }, [dates, newdleCode, participantCode, participantUnknown, user, dispatch]);
+  }, [dates, newdleCode, participantCode, participantUnknown, user, tz, dispatch]);
 
   if (!newdle || (participantCode && !participant)) {
     return null;

--- a/newdle/client/src/components/creation/timeslots/Availability.js
+++ b/newdle/client/src/components/creation/timeslots/Availability.js
@@ -4,6 +4,7 @@ import {
   getCreationCalendarActiveDate,
   getParticipantsWithUnkownAvailabilityForDate,
   getParticipantsBusyTimesForDate,
+  getTimezone,
 } from '../../../selectors';
 import {serializeDate} from '../../../util/date';
 import Timeline from './Timeline';
@@ -15,10 +16,11 @@ export default React.memo(function Availability() {
   const date = serializeDate(useSelector(getCreationCalendarActiveDate));
   const missing = useSelector(state => getParticipantsWithUnkownAvailabilityForDate(state, date));
   const busyTimes = useSelector(state => getParticipantsBusyTimesForDate(state, date));
+  const tz = useSelector(getTimezone);
 
   useEffect(() => {
-    dispatch(fetchParticipantBusyTimes(missing, date));
-  }, [dispatch, missing, date]);
+    dispatch(fetchParticipantBusyTimes(missing, date, tz));
+  }, [dispatch, missing, date, tz]);
 
   // explicit key to avoid keeping state between dates.
   // like this we automatically leave/enter edit mode based on whether

--- a/newdle/client/src/reducers/creation.js
+++ b/newdle/client/src/reducers/creation.js
@@ -79,6 +79,7 @@ export default combineReducers({
     switch (action.type) {
       case ABORT_CREATION:
       case NEWDLE_CREATED:
+      case SET_TIMEZONE: // if the timezone is reset, we need to fetch the busy times again
         return {};
       case REMOVE_PARTICIPANT:
         return _.mapValues(state, slots => _.omit(slots, action.participant.uid));

--- a/newdle/providers/free_busy/exchange.py
+++ b/newdle/providers/free_busy/exchange.py
@@ -1,28 +1,55 @@
 from datetime import datetime, time, timedelta
 
+import pytz
 from exchangelib import NTLM, Account, Configuration, Credentials
 from exchangelib.errors import (
     ErrorMailRecipientNotFound,
     ErrorProxyRequestProcessingFailed,
 )
 from flask import current_app
-from pytz import utc
 
 
 TYPE_MAP = {'Busy': 'busy', 'Tentative': 'busy', 'OOF': 'busy'}
 
+# These are deprecated North American timezones which are still in common use.
+# Exchange doesn't like them, so we have to map them to their standard names.
+# Mapping taken from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+NON_STANDARD_TZS = {
+    'US/Eastern': 'America/New_York',
+    'US/Pacific': 'America/Los_Angeles',
+    'US/Mountain': 'America/Denver',
+    'US/Central': 'America/Chicago',
+    'US/Arizona': 'America/Phoenix',
+    'US/Hawaii': 'Pacific/Honolulu',
+    'US/Alaska': 'America/Anchorage',
+    'Canada/Newfoundland': 'America/St_Johns',
+    'Canada/Atlantic': 'America/Halifax',
+    'Canada/Eastern': 'America/Toronto',
+    'Canada/Central': 'America/Winnipeg',
+    'Canada/Mountain': 'America/Edmonton',
+    'Canada/Pacific': 'America/Vancouver',
+}
 
-def find_overlap(day, start, end):
-    """Find the overlap of a day with a datetime range."""
-    latest_start = max(datetime.combine(day, time.min), start)
-    earliest_end = min(datetime.combine(day, time.max), end)
+
+def find_overlap(day, start, end, tz):
+    """Find the overlap of a day with a datetime range.
+
+    :param day: the day to calculate overlap for (00:00 - 23:59)
+    :param start: the start ``datetime`` of the range (tz-aware)
+    :param end: the end ``datetime`` of the range (tz-aware)
+    :param tz: the timezone of reference
+    """
+    latest_start = max(
+        tz.localize(datetime.combine(day, time.min)), start.astimezone(tz)
+    )
+    earliest_end = min(tz.localize(datetime.combine(day, time.max)), end.astimezone(tz))
     diff = (earliest_end - latest_start).days + 1
     if diff > 0:
         return latest_start.time(), earliest_end.time()
     return None
 
 
-def fetch_free_busy(date, uid):
+def fetch_free_busy(date, tz, uid):
     acc = current_app.config['EXCHANGE_PROVIDER_ACCOUNT']
     creds = current_app.config['EXCHANGE_PROVIDER_CREDENTIALS']
     server = current_app.config['EXCHANGE_PROVIDER_SERVER']
@@ -46,8 +73,13 @@ def fetch_free_busy(date, uid):
         ),
     ]
 
-    tz = uid_account.default_timezone
-    start = utc.localize(datetime.combine(date, time.min)).astimezone(tz)
+    if tz in NON_STANDARD_TZS:
+        tz = NON_STANDARD_TZS[tz]
+
+    tzinfo = pytz.timezone(tz)
+    account_tz = uid_account.default_timezone
+    # query the Exchange service using the account's timezone
+    start = tzinfo.localize(datetime.combine(date, time.min)).astimezone(account_tz)
     end = start + timedelta(hours=24)
 
     results = []
@@ -60,7 +92,12 @@ def fetch_free_busy(date, uid):
         for busy_info in info:
             if busy_info.view_type == 'FreeBusyMerged':
                 for event in busy_info.calendar_events or []:
-                    overlap = find_overlap(date, event.start, event.end)
+                    overlap = find_overlap(
+                        date,
+                        account_tz.localize(event.start),
+                        account_tz.localize(event.end),
+                        tzinfo,
+                    )
                     if event.busy_type in {'Busy', 'Tentative', 'OOF'} and overlap:
                         results.append(overlap)
     except (ErrorProxyRequestProcessingFailed, ErrorMailRecipientNotFound):

--- a/newdle/providers/free_busy/random.py
+++ b/newdle/providers/free_busy/random.py
@@ -6,7 +6,7 @@ def _to_tuple(t):
     return (t.hour, t.minute)
 
 
-def fetch_free_busy(date, uid):
+def fetch_free_busy(date, tz, uid):
     rnd = Random(date.isoformat() + uid)
     if rnd.randint(0, 1):
         start = rnd.randint(5, 21)


### PR DESCRIPTION
 * This PR makes it so that the free/busy views take into account the current timezone the user is in.
 * This means as well that, during the creation of the newdle, updates in the timezone field will result in the free/busy information being fetched again.
 * I have also fixed the handling of free/busy dates that fall outside the visible hour range.
 * In what concerns the Exchange part, I have made sure we operate using the account's timezone and then properly calculate the overlaps based on the newdle's timezone;
