### PR TITLE
Use actual newdle creator_name in summary header

### DIFF
--- a/newdle/client/src/components/summary/SummaryHeader.js
+++ b/newdle/client/src/components/summary/SummaryHeader.js
@@ -1,14 +1,12 @@
 import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {getNewdleTitle, getUserInfo, getNewdleFinalDt} from '../../selectors';
+import {getNewdle} from '../../selectors';
 import {clearNewdle, fetchNewdle} from '../../actions';
 import NewdleTitle from '../NewdleTitle';
 
 export default function SummaryHeader({match}) {
   const code = match.params.code;
-  const title = useSelector(getNewdleTitle);
-  const user = useSelector(getUserInfo);
-  const finalDt = useSelector(getNewdleFinalDt);
+  const newdle = useSelector(getNewdle);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -19,10 +17,17 @@ export default function SummaryHeader({match}) {
     };
   }, [code, dispatch]);
 
-  if (!title || !user) {
+  if (!newdle) {
     return null;
   }
 
-  const label = finalDt ? 'finished' : 'ongoing';
-  return <NewdleTitle title={title} author={user.name} label={label} finished={!!finalDt} />;
+  const label = newdle.final_dt ? 'finished' : 'ongoing';
+  return (
+    <NewdleTitle
+      title={newdle.title}
+      author={newdle.creator_name}
+      label={label}
+      finished={!!newdle.final_dt}
+    />
+  );
 }

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -82,10 +82,8 @@ export const getCreatedNewdle = state => state.creation.createdNewdle;
 
 // newdle
 export const getNewdle = state => state.newdle;
-export const getNewdleTitle = state => (state.newdle && state.newdle.title) || null;
 export const getNewdleTimeslots = state => (state.newdle && state.newdle.timeslots) || [];
 export const getNewdleDuration = state => state.newdle && state.newdle.duration;
-export const getNewdleFinalDt = state => (state.newdle && state.newdle.final_dt) || null;
 export const getNewdleParticipants = state => (state.newdle && state.newdle.participants) || [];
 export const getNumberOfParticipants = createSelector(
   getNewdleParticipants,


### PR DESCRIPTION
While only the creator can view the summary right now, this will eventually change and even right now the "broken" view when trying to view someone else's newdle shows the wrong name.

Also removed some selectors that aren't very useful since those values can be easily retrieved from the newdle object itself.