### PR TITLE
Use separate endpoint to get participant list

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,7 @@ def app():
         'SQLALCHEMY_DATABASE_URI': TEST_DATABASE_URI,
         'SERVER_NAME': 'flask.test',
         'SECRET_KEY': 'test',
-        'EMAIL_BACKEND': 'newdle.vendor.django_mail.backends.locmem.EmailBackend'
+        'EMAIL_BACKEND': 'newdle.vendor.django_mail.backends.locmem.EmailBackend',
     }
     app = create_app(config_override, use_env_config=False)
     ctx = app.app_context()

--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -143,11 +143,17 @@ export function setTitle(title) {
 
 export function fetchNewdle(code, fullDetails = false, action = NEWDLE_RECEIVED) {
   return async dispatch => {
-    const newdle = await client.catchErrors(client.getNewdle(code, fullDetails));
-
-    if (newdle !== undefined) {
-      dispatch({type: action, newdle});
+    const newdle = await client.catchErrors(client.getNewdle(code));
+    if (newdle === undefined) {
+      return;
     }
+    if (fullDetails) {
+      const participants = await client.catchErrors(client.getParticipants(code));
+      // fallback to null if we don't have access. that way we don't show a blank page
+      // but at least the information that is public anyway
+      newdle.participants = participants || null;
+    }
+    dispatch({type: action, newdle});
   };
 }
 

--- a/newdle/client/src/client.js
+++ b/newdle/client/src/client.js
@@ -133,8 +133,8 @@ class Client {
     return this._request(flask`api.create_newdle`(), params);
   }
 
-  getNewdle(code, fullDetails = false) {
-    return this._request(flask`api.get_newdle`({code}), {anonymous: !fullDetails});
+  getNewdle(code) {
+    return this._request(flask`api.get_newdle`({code}), {anonymous: true});
   }
 
   getMyNewdles() {
@@ -162,6 +162,10 @@ class Client {
       method: 'PATCH',
       body: JSON.stringify({final_dt: finalDate}),
     });
+  }
+
+  getParticipants(code) {
+    return this._request(flask`api.get_participants`({code}));
   }
 
   getParticipant(newdleCode, participantCode) {


### PR DESCRIPTION
This way we don't end up with a half-broken page when trying to view a Newdle we can't access.

The error display is still not amazing (403 error message from the failed API call) though. Ideally we;d check whether the user is the newdle's creator and if not either show a more user-friendly message or a simplified version (using just the public information that's available)

closes #157