### PR TITLE
Add "newdles I'm in" page to user profile

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -73,6 +73,11 @@ def dummy_uid():
 
 
 @pytest.fixture
+def dummy_participant_uid():
+    return 'pig'
+
+
+@pytest.fixture
 def dummy_newdle(db_session, dummy_uid):
     newdle = Newdle(
         code='dummy',

--- a/newdle/api.py
+++ b/newdle/api.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import date
 from importlib import import_module
 
 from faker import Faker
@@ -216,12 +215,7 @@ def get_newdles_participating():
     newdle = (
         Participant.query.filter_by(auth_uid=g.user['uid'])
         .join(Participant.newdle)
-        .order_by(
-            Participant.answers != '{}',
-            Newdle.final_dt >= date.today(),
-            Newdle.final_dt,
-            Newdle.id.desc(),
-        )
+        .order_by(Newdle.id.desc())
     )
     return NewdleParticipantSchema(many=True).jsonify(newdle)
 

--- a/newdle/api.py
+++ b/newdle/api.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 from importlib import import_module
 
 from faker import Faker
@@ -7,7 +8,7 @@ from itsdangerous import BadData, SignatureExpired
 from marshmallow import fields
 from marshmallow.validate import OneOf
 from pytz import common_timezones_set
-from sqlalchemy.orm import noload, selectinload
+from sqlalchemy.orm import selectinload
 from werkzeug.exceptions import Forbidden, UnprocessableEntity
 
 from .cern_integration import search_cern_users
@@ -19,6 +20,7 @@ from .models import Newdle, Participant
 from .notifications import notify_newdle_participants
 from .schemas import (
     MyNewdleSchema,
+    NewdleParticipantSchema,
     NewdleSchema,
     NewNewdleSchema,
     NewUnknownParticipantSchema,
@@ -209,15 +211,19 @@ def get_my_newdles():
     return MyNewdleSchema(many=True).jsonify(newdle)
 
 
-@api.route('/newdles/in')
-def get_newdles_im_in():
+@api.route('/newdles/participating')
+def get_newdles_participating():
     newdle = (
-        Newdle.query.options(noload('participants'))
-        .filter(Newdle.participants.any(auth_uid=g.user['uid']))
-        .order_by(Newdle.final_dt.isnot(None), Newdle.final_dt.desc(), Newdle.id.desc())
-        .all()
+        Participant.query.filter_by(auth_uid=g.user['uid'])
+        .join(Participant.newdle)
+        .order_by(
+            Participant.answers != '{}',
+            Newdle.final_dt >= date.today(),
+            Newdle.final_dt,
+            Newdle.id.desc(),
+        )
     )
-    return RestrictedNewdleSchema(many=True).jsonify(newdle)
+    return NewdleParticipantSchema(many=True).jsonify(newdle)
 
 
 @api.route('/newdle/', methods=('POST',))

--- a/newdle/client/src/client.js
+++ b/newdle/client/src/client.js
@@ -141,6 +141,10 @@ class Client {
     return this._request(flask`api.get_my_newdles`());
   }
 
+  getNewdlesImIn() {
+    return this._request(flask`api.get_newdles_im_in`());
+  }
+
   getBusyTimes(date, tz, uid, newdleCode = null, participantCode = null) {
     if (uid !== null) {
       return this._request(flask`api.get_busy_times`({date, uid, tz}));

--- a/newdle/client/src/client.js
+++ b/newdle/client/src/client.js
@@ -141,8 +141,8 @@ class Client {
     return this._request(flask`api.get_my_newdles`());
   }
 
-  getNewdlesImIn() {
-    return this._request(flask`api.get_newdles_im_in`());
+  getNewdlesParticipating() {
+    return this._request(flask`api.get_newdles_participating`());
   }
 
   getBusyTimes(date, tz, uid, newdleCode = null, participantCode = null) {

--- a/newdle/client/src/components/App.js
+++ b/newdle/client/src/components/App.js
@@ -10,7 +10,7 @@ import TopHeader from './TopHeader';
 import LoginPrompt from './login/LoginPrompt';
 import LoggingIn from './login/LoggingIn';
 import MyNewdles from './MyNewdles';
-import NewdlesImIn from './NewdlesImIn';
+import NewdlesParticipating from './NewdlesParticipating';
 import ErrorMessage from './ErrorMessage';
 
 import './App.module.scss';
@@ -31,7 +31,7 @@ export default function App() {
           <Route exact path="/new" component={CreationPage} />
           <Route exact path="/new/success" component={CreationSuccessPage} />
           <Route exact path="/mine" component={MyNewdles} />
-          <Route exact path="/in" component={NewdlesImIn} />
+          <Route exact path="/participating" component={NewdlesParticipating} />
           <Route path="/newdle/:code/summary" component={SummaryPage} />
           <Route exact path="/newdle/:code/:partcode?" component={AnswerPage} />
           <Route render={() => <div>This page does not exist</div>} />

--- a/newdle/client/src/components/App.js
+++ b/newdle/client/src/components/App.js
@@ -10,6 +10,7 @@ import TopHeader from './TopHeader';
 import LoginPrompt from './login/LoginPrompt';
 import LoggingIn from './login/LoggingIn';
 import MyNewdles from './MyNewdles';
+import NewdlesImIn from './NewdlesImIn';
 import ErrorMessage from './ErrorMessage';
 
 import './App.module.scss';
@@ -30,6 +31,7 @@ export default function App() {
           <Route exact path="/new" component={CreationPage} />
           <Route exact path="/new/success" component={CreationSuccessPage} />
           <Route exact path="/mine" component={MyNewdles} />
+          <Route exact path="/in" component={NewdlesImIn} />
           <Route path="/newdle/:code/summary" component={SummaryPage} />
           <Route exact path="/newdle/:code/:partcode?" component={AnswerPage} />
           <Route render={() => <div>This page does not exist</div>} />

--- a/newdle/client/src/components/MyNewdles.js
+++ b/newdle/client/src/components/MyNewdles.js
@@ -77,7 +77,7 @@ function MyNewdle({newdle: {code, title, participants, duration, final_dt: final
           <span>
             <Icon name="clock outline" />
             <label>
-              {`${startTime} - ${endTime}`} ({timezone})
+              {startTime} - {endTime} ({timezone})
             </label>
           </span>
         </div>

--- a/newdle/client/src/components/NewdlesImIn.js
+++ b/newdle/client/src/components/NewdlesImIn.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import {Container, Icon, Label, Placeholder} from 'semantic-ui-react';
+import {useHistory} from 'react-router';
+import {serializeDate, toMoment} from '../util/date';
+import client from '../client';
+import {usePageTitle} from '../util/hooks';
+import styles from './MyNewdles.module.scss';
+
+export default function NewdlesImIn() {
+  const [newdles, loading] = client.useBackend(() => client.getNewdlesImIn(), []);
+  usePageTitle("Newdles I'm in");
+
+  let content;
+  if (loading || newdles === null) {
+    content = (
+      <>
+        <Placeholder className={styles.newdle} />
+        <Placeholder className={styles.newdle} />
+        <Placeholder className={styles.newdle} />
+      </>
+    );
+  } else if (newdles.length === 0) {
+    content = (
+      <div className={styles['no-newdle-container']}>
+        {/* eslint-disable-next-line jsx-a11y/accessible-emoji */}
+        <h2>You are not part of any newdles yet... 🍜</h2>
+      </div>
+    );
+  } else {
+    content = newdles.map(newdle => <NewdleAsParticipant key={newdle.id} newdle={newdle} />);
+  }
+
+  return (
+    <Container text className={styles.newdles}>
+      {content}
+    </Container>
+  );
+}
+
+function NewdleAsParticipant({newdle: {code, title, duration, final_dt: finalDT, timezone}}) {
+  const history = useHistory();
+  const startTime = finalDT ? serializeDate(finalDT, 'HH:mm') : undefined;
+  const endTime = finalDT
+    ? serializeDate(toMoment(finalDT).add(duration, 'm'), 'HH:mm')
+    : undefined;
+  const url = `/newdle/${code}`;
+
+  return (
+    <div className={styles.newdle} onClick={() => history.push(url)}>
+      <h3 className={styles.title}>
+        <a href={url} onClick={evt => evt.preventDefault()}>
+          {title}
+        </a>
+        <Label color={finalDT ? 'blue' : 'green'} size="tiny" className={styles.state}>
+          {finalDT ? 'finished' : 'ongoing'}
+        </Label>
+      </h3>
+      {finalDT && (
+        <div className={styles.info}>
+          <span>
+            <Icon name="calendar alternate outline" />
+            <label>{serializeDate(finalDT, 'dddd, D MMMM')}</label>
+          </span>
+          <span>
+            <Icon name="clock outline" />
+            <label>
+              {`${startTime} - ${endTime}`} ({timezone})
+            </label>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/newdle/client/src/components/UserMenu.js
+++ b/newdle/client/src/components/UserMenu.js
@@ -39,10 +39,10 @@ export default function UserMenu() {
           My newdles
         </Dropdown.Item>
         <Dropdown.Item
-          href="/in"
+          href="/participating"
           onClick={evt => {
             evt.preventDefault();
-            history.push('/in');
+            history.push('/participating');
           }}
         >
           Newdles I'm In

--- a/newdle/client/src/components/UserMenu.js
+++ b/newdle/client/src/components/UserMenu.js
@@ -38,6 +38,15 @@ export default function UserMenu() {
         >
           My newdles
         </Dropdown.Item>
+        <Dropdown.Item
+          href="/in"
+          onClick={evt => {
+            evt.preventDefault();
+            history.push('/in');
+          }}
+        >
+          Newdles I'm In
+        </Dropdown.Item>
         <Dropdown.Item onClick={logout}>Log out</Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>

--- a/newdle/client/src/components/UserMenu.js
+++ b/newdle/client/src/components/UserMenu.js
@@ -45,7 +45,7 @@ export default function UserMenu() {
             history.push('/participating');
           }}
         >
-          Newdles I'm In
+          Newdles I'm in
         </Dropdown.Item>
         <Dropdown.Item onClick={logout}>Log out</Dropdown.Item>
       </Dropdown.Menu>

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -4,6 +4,7 @@ from enum import auto
 from flask import current_app
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.event import listens_for
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.schema import CheckConstraint
 
 from .core.db import db
@@ -92,9 +93,13 @@ class Participant(db.Model):
 
     newdle = db.relationship('Newdle', lazy=True, back_populates='participants')
 
-    @property
+    @hybrid_property
     def answers(self):
         return {parse_dt(k): Availability[v] for k, v in self._answers.items()}
+
+    @answers.expression
+    def answers(cls):
+        return cls._answers
 
     @answers.setter
     def answers(self, value):

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -126,3 +126,7 @@ class MyNewdleSchema(NewdleSchema):
 class RestrictedNewdleSchema(NewdleSchema):
     class Meta:
         exclude = ('participants',)
+
+
+class NewdleParticipantSchema(ParticipantSchema):
+    newdle = fields.Nested(RestrictedNewdleSchema)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -334,6 +334,41 @@ def test_update_newdle(flask_client, dummy_newdle, dummy_uid):
 
 
 @pytest.mark.usefixtures('db_session')
+def test_newdles_im_not_in(flask_client, dummy_uid):
+    resp = flask_client.get(
+        url_for('api.get_newdles_im_in'), **make_test_auth(dummy_uid)
+    )
+    assert resp.status_code == 200
+    assert resp.json == []
+
+
+@pytest.mark.usefixtures('db_session')
+def test_newdles_im_in(flask_client, dummy_newdle, dummy_participant_uid):
+    resp = flask_client.get(
+        url_for('api.get_newdles_im_in'), **make_test_auth(dummy_participant_uid)
+    )
+    assert resp.status_code == 200
+    assert resp.json == [
+        {
+            'code': 'dummy',
+            'creator_name': 'Dummy',
+            'duration': 60,
+            'final_dt': None,
+            'id': dummy_newdle.id,
+            'timezone': 'Europe/Zurich',
+            'timeslots': [
+                '2019-09-11T13:00',
+                '2019-09-11T14:00',
+                '2019-09-12T13:00',
+                '2019-09-12T13:30',
+            ],
+            'title': 'Test event',
+            'url': 'http://flask.test/newdle/dummy',
+        }
+    ]
+
+
+@pytest.mark.usefixtures('db_session')
 def test_get_participants_unauthorized(flask_client, dummy_newdle):
     resp = flask_client.get(
         url_for('api.get_participants', code='dummy'), **make_test_auth('someone')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -334,36 +334,44 @@ def test_update_newdle(flask_client, dummy_newdle, dummy_uid):
 
 
 @pytest.mark.usefixtures('db_session')
-def test_newdles_im_not_in(flask_client, dummy_uid):
+def test_newdles_not_participating(flask_client, dummy_uid):
     resp = flask_client.get(
-        url_for('api.get_newdles_im_in'), **make_test_auth(dummy_uid)
+        url_for('api.get_newdles_participating'), **make_test_auth(dummy_uid)
     )
     assert resp.status_code == 200
-    assert resp.json == []
+    assert not resp.json
 
 
 @pytest.mark.usefixtures('db_session')
-def test_newdles_im_in(flask_client, dummy_newdle, dummy_participant_uid):
+def test_newdles_participating(flask_client, dummy_newdle, dummy_participant_uid):
     resp = flask_client.get(
-        url_for('api.get_newdles_im_in'), **make_test_auth(dummy_participant_uid)
+        url_for('api.get_newdles_participating'),
+        **make_test_auth(dummy_participant_uid),
     )
     assert resp.status_code == 200
     assert resp.json == [
         {
-            'code': 'dummy',
-            'creator_name': 'Dummy',
-            'duration': 60,
-            'final_dt': None,
-            'id': dummy_newdle.id,
-            'timezone': 'Europe/Zurich',
-            'timeslots': [
-                '2019-09-11T13:00',
-                '2019-09-11T14:00',
-                '2019-09-12T13:00',
-                '2019-09-12T13:30',
-            ],
-            'title': 'Test event',
-            'url': 'http://flask.test/newdle/dummy',
+            'answers': {},
+            'auth_uid': dummy_participant_uid,
+            'code': 'part3',
+            'email': 'example@example.com',
+            'name': 'Guinea Pig',
+            'newdle': {
+                'code': 'dummy',
+                'creator_name': 'Dummy',
+                'duration': 60,
+                'final_dt': None,
+                'id': dummy_newdle.id,
+                'timeslots': [
+                    '2019-09-11T13:00',
+                    '2019-09-11T14:00',
+                    '2019-09-12T13:00',
+                    '2019-09-12T13:30',
+                ],
+                'timezone': 'Europe/Zurich',
+                'title': 'Test event',
+                'url': 'http://flask.test/newdle/dummy',
+            },
         }
     ]
 


### PR DESCRIPTION
Closes #164 

Some notes:
- Should "expired" newdles, i.e., with final date set be excluded?
- This PR doesn't change any of the page styles, should we add something to distinguish the two pages? A title such as "The newdles you are part of" and "The newdles you created", or merging the two together in the same page.
- A suggestion for an interesting feature would be, replacing the placeholder "x out of X participants answered" with something like "You chose the '2019-09-11T13:00' slot" or "You chose 3 slots", for the newdles-im-in page, since you can't see the participants.