### PR TITLE
Use real emails for CERN accounts

### DIFF
--- a/newdle/cern_integration.py
+++ b/newdle/cern_integration.py
@@ -36,15 +36,20 @@ def search_cern_users(q, limit):
         params={
             'limit': limit,
             'filter': ['type:eq:Person', 'source:eq:cern', f'displayName:contains:{q}'],
-            'field': ['upn', 'displayName', 'firstName', 'lastName'],
+            'field': [
+                'upn',
+                'displayName',
+                'firstName',
+                'lastName',
+                'primaryAccountEmail',
+            ],
             'sort': ['displayName', 'upn'],
         },
     )
     data = res.json()
     users = [
         {
-            # the api doesn't return emails yet...
-            'email': f"{user['upn']}@cern.ch",
+            'email': user['primaryAccountEmail'],
             'first_name': user['firstName'],
             'last_name': user['lastName'],
             'uid': user['upn'],


### PR DESCRIPTION
Do not merge this until the API actually returns real emails there and it's confirmed that our app id has access to it.