### PR TITLE
Add the missing lint scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,9 @@ lint:
 	@printf "  \033[38;5;154mDEV\033[0m  \033[38;5;77mLinting code\033[0m\n"
 	@npm run pycodestyle
 	@npm run flake8
+	@npm run prettier:check
+	@npm run isort:check
+	@npm run black:check
 
 
 .PHONY: newdb

--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "private": true,
   "scripts": {
     "prettier": "prettier --write 'newdle/client/src/**/*.{js,jsx,json,scss,css}'",
+    "prettier:check": "prettier --check 'newdle/client/src/**/*.{js,jsx,json,scss,css}'",
     "isort": "isort --recursive setup.py conftest.py newdle/ tests/",
+    "isort:check": "npm run isort -- --diff --check-only",
     "black": "black setup.py conftest.py newdle/ tests/",
+    "black:check": "npm run black -- --diff --check",
     "pycodestyle": "pycodestyle conftest.py newdle/ tests/",
     "flake8": "flake8 conftest.py newdle/ tests/"
   },
@@ -27,6 +30,6 @@
   "devDependencies": {
     "husky": "^3.0.9",
     "lint-staged": "^9.4.2",
-    "prettier": "^1.18.2"
+    "prettier": "~1.18.2"
   }
 }


### PR DESCRIPTION
Update the lint step to check the code style without applying any changes.
Also, lock the prettier version to 1.18 to prevent 1.19 new function literal heuristic (refer to prettier's #6921).

Closes #172 