### PR TITLE
Make default time for timeslots smarter

### DIFF
--- a/newdle/client/src/components/creation/timeslots/Timeline.js
+++ b/newdle/client/src/components/creation/timeslots/Timeline.js
@@ -8,6 +8,7 @@ import {
   getCreationCalendarActiveDate,
   getDuration,
   getTimeslotsForActiveDate,
+  getNewTimeslotStartTime,
 } from '../../../selectors';
 import CandidateSlot from './CandidateSlot';
 import DurationPicker from './DurationPicker';
@@ -15,12 +16,10 @@ import TimezonePicker from './TimezonePicker';
 import TimelineRow from './TimelineRow';
 import TimelineHeader from './TimelineHeader';
 import {addTimeslot, removeTimeslot} from '../../../actions';
-import {hourRange, toMoment, getHourSpan} from '../../../util/date';
+import {hourRange, toMoment, getHourSpan, DEFAULT_TIME_FORMAT} from '../../../util/date';
 import styles from './Timeline.module.scss';
 
 const OVERFLOW_WIDTH = 0.5;
-const DEFAULT_SLOT_START_TIME = '10:00';
-const DEFAULT_TIME_FORMAT = 'HH:mm';
 
 function calculateWidth(start, end, minHour, maxHour) {
   let startMins = start.hours() * 60 + start.minutes();
@@ -159,8 +158,13 @@ function TimelineInput({minHour, maxHour}) {
   const date = useSelector(getCreationCalendarActiveDate);
   const candidates = useSelector(getTimeslotsForActiveDate);
   const [editing, setEditing] = useState(!!candidates.length);
-  const [timeslotTime, setTimeslotTime] = useState(DEFAULT_SLOT_START_TIME);
+  const latestStartTime = useSelector(getNewTimeslotStartTime);
+  const [timeslotTime, setTimeslotTime] = useState(latestStartTime);
   const [newTimeslotPopupOpen, setTimeslotPopupOpen] = useState(false);
+
+  useEffect(() => {
+    setTimeslotTime(latestStartTime);
+  }, [latestStartTime, candidates, duration]);
 
   const handleStartEditing = () => {
     setEditing(true);
@@ -169,7 +173,6 @@ function TimelineInput({minHour, maxHour}) {
 
   const handlePopupClose = () => {
     setTimeslotPopupOpen(false);
-    setTimeslotTime(DEFAULT_SLOT_START_TIME);
   };
 
   const handleAddSlot = time => {

--- a/newdle/client/src/components/creation/timeslots/Timeline.js
+++ b/newdle/client/src/components/creation/timeslots/Timeline.js
@@ -9,6 +9,7 @@ import {
   getDuration,
   getTimeslotsForActiveDate,
   getNewTimeslotStartTime,
+  getPreviousDayTimeslots,
 } from '../../../selectors';
 import CandidateSlot from './CandidateSlot';
 import DurationPicker from './DurationPicker';
@@ -157,6 +158,7 @@ function TimelineInput({minHour, maxHour}) {
   const duration = useSelector(getDuration);
   const date = useSelector(getCreationCalendarActiveDate);
   const candidates = useSelector(getTimeslotsForActiveDate);
+  const pastCandidates = useSelector(getPreviousDayTimeslots);
   const [editing, setEditing] = useState(!!candidates.length);
   const latestStartTime = useSelector(getNewTimeslotStartTime);
   const [timeslotTime, setTimeslotTime] = useState(latestStartTime);
@@ -169,6 +171,13 @@ function TimelineInput({minHour, maxHour}) {
   const handleStartEditing = () => {
     setEditing(true);
     setTimeslotPopupOpen(true);
+  };
+
+  const handleCopyClick = () => {
+    pastCandidates.forEach(time => {
+      dispatch(addTimeslot(date, time));
+    });
+    setEditing(true);
   };
 
   const handlePopupClose = () => {
@@ -252,9 +261,17 @@ function TimelineInput({minHour, maxHour}) {
       />
     </div>
   ) : (
-    <div className={`${styles['timeline-input']} ${styles['msg']}`} onClick={handleStartEditing}>
-      <Icon name="plus circle" size="large" />
-      Click to add time slots
+    <div className={styles['timeline-input-wrapper']}>
+      <div className={`${styles['timeline-input']} ${styles['msg']}`} onClick={handleStartEditing}>
+        <Icon name="plus circle" size="large" />
+        Click to add time slots
+      </div>
+      {pastCandidates && (
+        <div className={`${styles['timeline-input']} ${styles['msg']}`} onClick={handleCopyClick}>
+          <Icon name="copy" size="large" />
+          Copy time slots from previous day
+        </div>
+      )}
     </div>
   );
 }

--- a/newdle/client/src/components/creation/timeslots/Timeline.module.scss
+++ b/newdle/client/src/components/creation/timeslots/Timeline.module.scss
@@ -127,6 +127,11 @@ $label-width: 180px;
     }
   }
 
+  .timeline-input-wrapper {
+    display: flex;
+    margin-left: -5px;
+  }
+
   .timeline-input {
     opacity: 0.6;
     display: flex;
@@ -135,6 +140,8 @@ $label-width: 180px;
     background-color: lighten($grey, 45%);
     border-radius: 3px;
     box-sizing: content-box;
+    flex-basis: 100%;
+    margin-left: 5px;
 
     .timeline-candidates {
       display: flex;

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -113,18 +113,26 @@ export const getParticipantAvailability = createSelector(
       x => x.startDt !== final_dt
     )
 );
-export const getNewTimeslotStartTime = createSelector(
+export const getPreviousDayTimeslots = createSelector(
   _getAllTimeslots,
   getCreationCalendarActiveDate,
-  getDuration,
-  (timeslots, date, duration) => {
+  (timeslots, date) => {
     const closestDate = Object.keys(timeslots)
       .sort()
       .filter(x => x < date)
       .pop();
+    return closestDate ? timeslots[closestDate] : null;
+  }
+);
+export const getNewTimeslotStartTime = createSelector(
+  _getAllTimeslots,
+  getCreationCalendarActiveDate,
+  getPreviousDayTimeslots,
+  getDuration,
+  (timeslots, date, pastTimeslots, duration) => {
     const slotsOnDate = new Set(timeslots[date] || []);
-    if (closestDate) {
-      const unusedSlots = timeslots[closestDate].filter(slot => !slotsOnDate.has(slot)).sort();
+    if (pastTimeslots !== null) {
+      const unusedSlots = pastTimeslots.filter(slot => !slotsOnDate.has(slot)).sort();
       // do we have an unused slot from the previous date?
       if (unusedSlots.length) {
         return unusedSlots[0];

--- a/newdle/client/src/util/date.js
+++ b/newdle/client/src/util/date.js
@@ -1,5 +1,7 @@
 import moment, {HTML5_FMT} from 'moment';
 
+export const DEFAULT_TIME_FORMAT = 'HH:mm';
+
 export function toMoment(date, format = null) {
   return date ? moment(date, format) : null;
 }


### PR DESCRIPTION
Default time for timeslots will now be either the end of the previous one or the first unused one of the previous date, depending on whether there are timeslots on the current day already.
Closes #188.