### PR TITLE
Add option to make newdle summary public/private

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -85,6 +85,7 @@ def dummy_newdle(db_session, dummy_uid):
         creator_uid=dummy_uid,
         creator_name='Dummy',
         duration=timedelta(minutes=60),
+        private=True,
         timezone='Europe/Zurich',
         timeslots=[
             datetime(2019, 9, 11, 13, 0),

--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -22,6 +22,7 @@ export const SET_DURATION = 'Set meeting duration';
 export const ADD_TIMESLOT = 'Add new timeslot';
 export const REMOVE_TIMESLOT = 'Remove a timeslot';
 export const SET_TITLE = 'Set title for Newdle';
+export const SET_PRIVATE = 'Keep list of participants private';
 export const SET_TIMEZONE = 'Set the meeting timezone';
 export const NEWDLE_RECEIVED = 'Received newdle data';
 export const CLEAR_NEWDLE = 'Clear newdle data';
@@ -139,6 +140,10 @@ export function removeTimeslot(date, time) {
 
 export function setTitle(title) {
   return {type: SET_TITLE, title};
+}
+
+export function setPrivate(isPrivate) {
+  return {type: SET_PRIVATE, private: isPrivate};
 }
 
 export function fetchNewdle(code, fullDetails = false, action = NEWDLE_RECEIVED) {

--- a/newdle/client/src/client.js
+++ b/newdle/client/src/client.js
@@ -125,16 +125,23 @@ class Client {
     return this._request(flask`api.users`({name, email}));
   }
 
-  createNewdle(title, duration, timezone, timeslots, participants) {
+  createNewdle(title, duration, timezone, timeslots, participants, isPrivate) {
     const params = {
       method: 'POST',
-      body: JSON.stringify({title, duration, timezone, timeslots, participants}),
+      body: JSON.stringify({
+        title,
+        duration,
+        timezone,
+        timeslots,
+        participants,
+        private: isPrivate,
+      }),
     };
     return this._request(flask`api.create_newdle`(), params);
   }
 
   getNewdle(code) {
-    return this._request(flask`api.get_newdle`({code}), {anonymous: true});
+    return this._request(flask`api.get_newdle`({code}), {anonymous: !this.token});
   }
 
   getMyNewdles() {
@@ -169,7 +176,7 @@ class Client {
   }
 
   getParticipants(code) {
-    return this._request(flask`api.get_participants`({code}));
+    return this._request(flask`api.get_participants`({code}), {anonymous: !this.token});
   }
 
   getParticipant(newdleCode, participantCode) {

--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -1,20 +1,60 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Container, Label} from 'semantic-ui-react';
+import {useSelector} from 'react-redux';
+import {useHistory} from 'react-router';
+import {useRouteMatch} from 'react-router-dom';
+import {Container, Icon, Button, Popup} from 'semantic-ui-react';
+import {getUserInfo} from '../selectors';
 import styles from './NewdleTitle.module.scss';
 
-export default function NewdleTitle({title, author, label, finished}) {
+export default function NewdleTitle({title, author, creatorUid, finished, code, isPrivate}) {
+  const userInfo = useSelector(getUserInfo);
+  const history = useHistory();
+  const isSummary = !!useRouteMatch({path: '/newdle/:code/summary'});
+
   return (
-    <Container text className={styles.box}>
-      <div className={styles.title}>
-        <h1 className={styles.header}>{title}</h1>
-        {label && (
-          <Label basic color={finished ? 'blue' : 'green'} size="tiny" className={styles.label}>
-            {label}
-          </Label>
+    <Container text className={styles['box']}>
+      <div className={styles['flexbox']}>
+        <div>
+          <div className={styles['title']}>
+            <h1 className={styles['header']}>{title}</h1>
+          </div>
+          <div className={styles['subtitle']}>by {author}</div>
+        </div>
+        {(!isPrivate || (userInfo && userInfo.uid === creatorUid)) && (
+          <div className={styles['view-options']}>
+            <Button.Group>
+              <Popup
+                content={!finished ? 'Answer newdle' : 'This newdle has already finished'}
+                position="bottom center"
+                trigger={
+                  <Button
+                    icon
+                    active={!isSummary}
+                    onClick={() => (isSummary ? history.push(`/newdle/${code}/`) : null)}
+                    disabled={finished}
+                  >
+                    <Icon name="calendar plus outline" />
+                  </Button>
+                }
+              />
+              <Popup
+                content="View summary"
+                position="bottom center"
+                trigger={
+                  <Button
+                    icon
+                    active={isSummary}
+                    onClick={() => (!isSummary ? history.push(`/newdle/${code}/summary`) : null)}
+                  >
+                    <Icon name="tasks" />
+                  </Button>
+                }
+              />
+            </Button.Group>
+          </div>
         )}
       </div>
-      <div className={styles.subtitle}>by {author}</div>
     </Container>
   );
 }
@@ -22,8 +62,11 @@ export default function NewdleTitle({title, author, label, finished}) {
 NewdleTitle.propTypes = {
   title: PropTypes.string.isRequired,
   author: PropTypes.string.isRequired,
+  creatorUid: PropTypes.string.isRequired,
   label: PropTypes.string,
   finished: PropTypes.bool,
+  code: PropTypes.string.isRequired,
+  isPrivate: PropTypes.bool.isRequired,
 };
 
 NewdleTitle.defaultProps = {

--- a/newdle/client/src/components/NewdleTitle.module.scss
+++ b/newdle/client/src/components/NewdleTitle.module.scss
@@ -21,4 +21,15 @@
 .box {
   padding: 15px 1.5em;
   background-color: $white;
+
+  .flexbox {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .view-options {
+    display: flex;
+    align-items: center;
+  }
 }

--- a/newdle/client/src/components/ParticipantTable.js
+++ b/newdle/client/src/components/ParticipantTable.js
@@ -66,6 +66,7 @@ function AvailabilityRow({
   setActiveDate,
   active,
   finalized,
+  isCreator,
   children,
 }) {
   const numberOfParticipants = useSelector(getNumberOfParticipants);
@@ -75,12 +76,12 @@ function AvailabilityRow({
   return (
     <Table.Row
       className={
-        finalized
+        finalized || !isCreator
           ? `${styles['participant-row']} ${styles['finalized']}`
           : styles['participant-row']
       }
       style={!finalized || active ? null : {opacity: '0.3'}}
-      onClick={() => (finalized ? null : setActiveDate(startDt))}
+      onClick={() => (finalized || !isCreator ? null : setActiveDate(startDt))}
       active={active}
     >
       <Table.Cell width={3}>
@@ -114,7 +115,7 @@ function AvailabilityRow({
         </div>
         {active && children}
       </Table.Cell>
-      {!finalized && (
+      {!finalized && isCreator && (
         <Table.Cell width={1} textAlign="right">
           <Radio name="slot-id" value={startDt} checked={active} />
         </Table.Cell>
@@ -141,6 +142,7 @@ AvailabilityRow.propTypes = {
   setActiveDate: PropTypes.func.isRequired,
   active: PropTypes.bool.isRequired,
   finalized: PropTypes.bool.isRequired,
+  isCreator: PropTypes.bool.isRequired,
   children: PropTypes.node,
 };
 
@@ -148,7 +150,13 @@ AvailabilityRow.defaultProps = {
   children: null,
 };
 
-export default function ParticipantTable({finalDate, setFinalDate, finalized, children}) {
+export default function ParticipantTable({
+  finalDate,
+  setFinalDate,
+  finalized,
+  isCreator,
+  children,
+}) {
   const availabilityData = useSelector(getParticipantAvailability);
 
   if (availabilityData.length === 0) {
@@ -157,7 +165,7 @@ export default function ParticipantTable({finalDate, setFinalDate, finalized, ch
 
   return (
     <div className={styles['participant-table']}>
-      <Table textAlign="center" definition selectable={!finalized}>
+      <Table textAlign="center" definition selectable={!finalized && isCreator}>
         <Table.Body>
           {availabilityData.map(availability => (
             <AvailabilityRow
@@ -166,6 +174,7 @@ export default function ParticipantTable({finalDate, setFinalDate, finalized, ch
               setActiveDate={setFinalDate}
               active={availability.startDt === finalDate}
               finalized={finalized}
+              isCreator={isCreator}
             >
               {children}
             </AvailabilityRow>
@@ -180,6 +189,7 @@ ParticipantTable.propTypes = {
   finalDate: PropTypes.string,
   setFinalDate: PropTypes.func.isRequired,
   finalized: PropTypes.bool.isRequired,
+  isCreator: PropTypes.bool.isRequired,
   children: PropTypes.node,
 };
 

--- a/newdle/client/src/components/answer/AnswerHeader.js
+++ b/newdle/client/src/components/answer/AnswerHeader.js
@@ -22,7 +22,16 @@ export default function AnswerHeader({match}) {
     return null;
   }
 
-  return <NewdleTitle title={newdle.title} author={newdle.creator_name} />;
+  return (
+    <NewdleTitle
+      title={newdle.title}
+      author={newdle.creator_name}
+      creatorUid={newdle.creator_uid}
+      finished={!!newdle.final_dt}
+      code={newdle.code}
+      isPrivate={newdle.private}
+    />
+  );
 }
 
 AnswerHeader.propTypes = {

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -124,7 +124,7 @@ export default function AnswerPage() {
   }, [newdle, user, participantCode, dispatch, submitting]);
 
   useEffect(() => {
-    if (user && !participantCode && participant) {
+    if (newdle && user && !participantCode && participant) {
       history.replace(`/newdle/${newdle.code}/${participant.code}`);
     }
   }, [newdle, user, participant, history, participantCode]);

--- a/newdle/client/src/components/creation/FinalStep.js
+++ b/newdle/client/src/components/creation/FinalStep.js
@@ -1,20 +1,22 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useHistory} from 'react-router';
-import {Button, Container, Header, Input} from 'semantic-ui-react';
+import {Button, Container, Header, Icon, Input, Checkbox} from 'semantic-ui-react';
 import {
   getDuration,
   getFullTimeslots,
   getParticipantData,
   getTimezone,
   getTitle,
+  getPrivacySetting,
 } from '../../selectors';
 import client from '../../client';
-import {newdleCreated, setStep, setTitle} from '../../actions';
+import {newdleCreated, setStep, setTitle, setPrivate} from '../../actions';
 import styles from './creation.module.scss';
 
 export default function FinalStep() {
   const title = useSelector(getTitle);
+  const isPrivate = useSelector(getPrivacySetting);
   const duration = useSelector(getDuration);
   const timeslots = useSelector(getFullTimeslots);
   const participants = useSelector(getParticipantData);
@@ -22,9 +24,17 @@ export default function FinalStep() {
   const dispatch = useDispatch();
   const history = useHistory();
   const [_createNewdle, submitting] = client.useBackendLazy(client.createNewdle);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
 
   async function createNewdle() {
-    const newdle = await _createNewdle(title, duration, timezone, timeslots, participants);
+    const newdle = await _createNewdle(
+      title,
+      duration,
+      timezone,
+      timeslots,
+      participants,
+      isPrivate
+    );
 
     if (newdle) {
       dispatch(newdleCreated(newdle));
@@ -66,6 +76,29 @@ export default function FinalStep() {
             Once the newdle is created, you will be shown a link which you need to send to anyone
             you wish to invite.
           </p>
+        )}
+      </div>
+      <div className={styles['advanced-options']}>
+        <div
+          className={styles['headerbar']}
+          onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
+        >
+          <Header as="h3" className={styles['header']}>
+            Advanced options
+          </Header>
+          <Icon name={showAdvancedOptions ? 'chevron up' : 'chevron down'} />
+        </div>
+        {showAdvancedOptions && (
+          <div className={styles['options']}>
+            <label htmlFor="togglePrivate">Keep list of participants private</label>
+            <Checkbox
+              id="togglePrivate"
+              toggle
+              checked={isPrivate}
+              disabled={submitting}
+              onChange={(_, {checked}) => dispatch(setPrivate(checked))}
+            />
+          </div>
         )}
       </div>
       <div className={styles['create-button']}>

--- a/newdle/client/src/components/creation/creation.module.scss
+++ b/newdle/client/src/components/creation/creation.module.scss
@@ -59,3 +59,32 @@
     color: $light-teal !important;
   }
 }
+
+.advanced-options {
+  margin-bottom: 50px;
+  border: 1px solid #bbe;
+  border-radius: 3px;
+  padding: 15px 15px 0 15px;
+
+  .headerbar {
+    display: flex;
+    justify-content: space-between;
+    color: #8c8ce6;
+
+    :global(.ui.header) {
+      color: #8c8ce6;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  .options {
+    display: flex;
+    justify-content: space-between;
+    margin: 1em 0 0 1em;
+    color: #808080;
+    padding-bottom: 15px;
+  }
+}

--- a/newdle/client/src/components/summary/SummaryHeader.js
+++ b/newdle/client/src/components/summary/SummaryHeader.js
@@ -22,13 +22,14 @@ export default function SummaryHeader({match}) {
     return null;
   }
 
-  const label = newdle.final_dt ? 'finished' : 'ongoing';
   return (
     <NewdleTitle
       title={newdle.title}
       author={newdle.creator_name}
-      label={label}
+      creatorUid={newdle.creator_uid}
       finished={!!newdle.final_dt}
+      code={newdle.code}
+      isPrivate={newdle.private}
     />
   );
 }

--- a/newdle/client/src/components/summary/SummaryPage.js
+++ b/newdle/client/src/components/summary/SummaryPage.js
@@ -7,6 +7,7 @@ import {
   getNewdle,
   newdleHasParticipantsWithEmail,
   newdleHasParticipantsWithoutEmail,
+  getUserInfo,
 } from '../../selectors';
 import {updateNewdle} from '../../actions';
 import client from '../../client';
@@ -19,6 +20,8 @@ export default function SummaryPage() {
   const hasParticipantsWithEmail = useSelector(newdleHasParticipantsWithEmail);
   const hasParticipantsWithoutEmail = useSelector(newdleHasParticipantsWithoutEmail);
   const missingParticipants = useSelector(getMissingParticipants);
+  const userInfo = useSelector(getUserInfo);
+  const isCreator = userInfo !== null && newdle !== null && userInfo.uid === newdle.creator_uid;
   const dispatch = useDispatch();
   const [_sendResultEmails, mailSending, mailError, sendMailResponse] = client.useBackendLazy(
     client.sendResultEmails
@@ -66,29 +69,41 @@ export default function SummaryPage() {
             <Header className={styles.header} as="h2">
               {newdle.title} will take place on:
             </Header>
-            <ParticipantTable finalDate={newdle.final_dt} setFinalDate={setFinalDate} finalized>
-              <div className={styles['button-row']}>
-                {hasParticipantsWithEmail && (
-                  <Button
-                    icon
-                    color="blue"
-                    labelPosition="left"
-                    loading={mailSending}
-                    disabled={mailSending || mailSent}
-                    onClick={sendResultEmails}
-                  >
-                    <Icon name="mail" />
-                    E-mail participants
-                  </Button>
-                )}
-                <Button className={styles['create-event-button']}>Create event</Button>
-              </div>
+            <ParticipantTable
+              finalDate={newdle.final_dt}
+              setFinalDate={setFinalDate}
+              isCreator={isCreator}
+              finalized
+            >
+              {isCreator && (
+                <div className={styles['button-row']}>
+                  {hasParticipantsWithEmail && (
+                    <Button
+                      icon
+                      color="blue"
+                      labelPosition="left"
+                      loading={mailSending}
+                      disabled={mailSending || mailSent}
+                      onClick={sendResultEmails}
+                    >
+                      <Icon name="mail" />
+                      E-mail participants
+                    </Button>
+                  )}
+                  <Button className={styles['create-event-button']}>Create event</Button>
+                </div>
+              )}
             </ParticipantTable>
           </div>
         </>
       ) : (
         <>
-          <ParticipantTable finalDate={finalDate} setFinalDate={setFinalDate} finalized={false} />
+          <ParticipantTable
+            finalDate={finalDate}
+            setFinalDate={setFinalDate}
+            finalized={false}
+            isCreator={isCreator}
+          />
           {!!missingParticipants.length && (
             <div className={styles['missing-participants']}>
               <Table>
@@ -108,17 +123,19 @@ export default function SummaryPage() {
               </Table>
             </div>
           )}
-          <div className={styles['button-row']}>
-            <Button
-              type="submit"
-              loading={submitting}
-              disabled={!finalDate}
-              className={styles['finalize-button']}
-              onClick={update}
-            >
-              Select final date
-            </Button>
-          </div>
+          {isCreator && (
+            <div className={styles['button-row']}>
+              <Button
+                type="submit"
+                loading={submitting}
+                disabled={!finalDate}
+                className={styles['finalize-button']}
+                onClick={update}
+              >
+                Select final date
+              </Button>
+            </div>
+          )}
         </>
       )}
     </Container>

--- a/newdle/client/src/reducers/creation.js
+++ b/newdle/client/src/reducers/creation.js
@@ -14,6 +14,7 @@ import {
   SET_STEP,
   SET_TIMEZONE,
   SET_TITLE,
+  SET_PRIVATE,
 } from '../actions';
 
 const DEFAULT_DURATION = 30;
@@ -131,6 +132,17 @@ export default combineReducers({
         return moment.tz.guess();
       case SET_TIMEZONE:
         return action.timezone;
+      default:
+        return state;
+    }
+  },
+  private: (state = false, action) => {
+    switch (action.type) {
+      case ABORT_CREATION:
+      case NEWDLE_CREATED:
+        return false;
+      case SET_PRIVATE:
+        return action.private;
       default:
         return state;
     }

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -72,6 +72,7 @@ export const shouldConfirmAbortCreation = createSelector(
   (timeslots, hasParticipants) => !!Object.keys(timeslots).length || hasParticipants
 );
 export const getTitle = state => state.creation.title;
+export const getPrivacySetting = state => state.creation.private;
 export const getFullTimeslots = state =>
   [].concat(
     ...Object.entries(state.creation.timeslots).map(([date, slots]) =>

--- a/newdle/migrations/versions/20200814_1707_93a638b96375_add_private_column_to_newdle_model.py
+++ b/newdle/migrations/versions/20200814_1707_93a638b96375_add_private_column_to_newdle_model.py
@@ -1,0 +1,30 @@
+"""Add private column to Newdle model
+
+Revision ID: 93a638b96375
+Revises: 000000000000
+Create Date: 2020-08-14 17:07:47.546630
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '93a638b96375'
+down_revision = '000000000000'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'newdles',
+        sa.Column('private', sa.Boolean(), nullable=False, server_default='true'),
+    )
+    op.alter_column(
+        'newdles', 'private', server_default='false',
+    )
+
+
+def downgrade():
+    op.drop_column('newdles', 'private')

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -44,6 +44,9 @@ class Newdle(db.Model):
     timezone = db.Column(db.String, nullable=False)
     timeslots = db.Column(ARRAY(db.DateTime()), nullable=False)
     final_dt = db.Column(db.DateTime(), nullable=True)
+    private = db.Column(
+        db.Boolean, nullable=False, default=False, server_default='false'
+    )
     code = db.Column(
         db.String,
         nullable=False,

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -101,6 +101,7 @@ class NewNewdleSchema(mm.Schema):
     )
     participants = fields.List(fields.Nested(NewKnownParticipantSchema), missing=[])
     final_dt = fields.DateTime(format=DATETIME_FORMAT)
+    private = fields.Boolean(required=True)
 
     @validates('timeslots')
     def validate_timeslots(self, v):
@@ -111,12 +112,14 @@ class NewNewdleSchema(mm.Schema):
 class NewdleSchema(NewNewdleSchema):
     id = fields.Integer()
     creator_name = fields.String()
+    creator_uid = fields.String()
     code = fields.String()
     final_dt = fields.DateTime(format=DATETIME_FORMAT)
     url = fields.Function(
         lambda newdle: url_for('newdle', code=newdle.code, _external=True)
     )
     participants = fields.List(fields.Nested(RestrictedParticipantSchema))
+    private = fields.Boolean()
 
 
 class MyNewdleSchema(NewdleSchema):


### PR DESCRIPTION
Participants can now look at the summary of newdles (to see how others have voted) if it is set to public by the creator.
For already existing newdles it is still set to private, however.
Closes #174.
<img width="717" alt="Bildschirmfoto 2020-08-19 um 13 56 19" src="https://user-images.githubusercontent.com/23189858/90631914-d431fd00-e223-11ea-8f6f-e9fd0f58f213.png">
<img width="738" alt="Bildschirmfoto 2020-08-19 um 13 56 28" src="https://user-images.githubusercontent.com/23189858/90631919-d5632a00-e223-11ea-8dc1-caada5112114.png">

![Bildschirmfoto 2020-08-20 um 16 04 55](https://user-images.githubusercontent.com/23189858/90781527-f0ef3300-e2fe-11ea-9124-d1257635ade5.png)
![Bildschirmfoto 2020-08-20 um 16 05 00](https://user-images.githubusercontent.com/23189858/90781540-f2206000-e2fe-11ea-958b-ffb2ff9c92dd.png)
