### PR TITLE
Preserve participant code when switching views

### DIFF
--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -28,6 +28,8 @@ export const NEWDLE_RECEIVED = 'Received newdle data';
 export const CLEAR_NEWDLE = 'Clear newdle data';
 export const ANSWER_NEWDLE_RECEIVED = 'Received newdle data for answering';
 export const ABORT_ANSWERING = 'Abort answering';
+export const SET_PARTICIPANT_CODE = 'Set the current participant code';
+export const CLEAR_PARTICIPANT_CODES = 'Clear all participant codes';
 export const SET_ANSWER = 'Set newdle answer';
 export const REPLACE_ANSWERS = 'Replace newdle answers';
 export const SET_ANSWER_ACTIVE_DATE = 'Change answer selected date';
@@ -164,6 +166,14 @@ export function fetchNewdle(code, fullDetails = false, action = NEWDLE_RECEIVED)
 
 export function fetchNewdleForAnswer(code) {
   return fetchNewdle(code, false, ANSWER_NEWDLE_RECEIVED);
+}
+
+export function setParticipantCode(newdleCode, participantCode) {
+  return {type: SET_PARTICIPANT_CODE, newdleCode, participantCode};
+}
+
+export function clearParticipantCodes() {
+  return {type: CLEAR_PARTICIPANT_CODES};
 }
 
 export function clearNewdle() {

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -139,4 +139,17 @@ export const haveParticipantAnswersChanged = createSelector(
   }
 );
 
+/**
+ * Get the participant code that was previously stored for a given newdle.
+ * This is meant to be used when switching between summary and answer view
+ * in order to not lose the previously-viewed participant when switching back
+ * in case that participant was not linked to the current user (or there is no
+ * current user).
+ */
+export const getStoredParticipantCodeForNewdle = createSelector(
+  state => state.answer.participantCodes,
+  (_, newdleCode) => newdleCode,
+  (participantCodes, newdleCode) => participantCodes[newdleCode] || null
+);
+
 // TODO: move this to selectors/answers.js (and split selectors.js as well)

--- a/newdle/client/src/components/MyNewdles.js
+++ b/newdle/client/src/components/MyNewdles.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, {useEffect} from 'react';
+import {useDispatch} from 'react-redux';
 import PropTypes from 'prop-types';
 import {Button, Container, Icon, Label, Placeholder} from 'semantic-ui-react';
 import {useHistory} from 'react-router';
+import {clearParticipantCodes} from '../actions';
 import {serializeDate, toMoment} from '../util/date';
 import client from '../client';
 import {usePageTitle} from '../util/hooks';
@@ -10,7 +12,19 @@ import styles from './MyNewdles.module.scss';
 export default function MyNewdles() {
   const [newdles, loading] = client.useBackend(() => client.getMyNewdles(), []);
   const history = useHistory();
+  const dispatch = useDispatch();
   usePageTitle('My newdles');
+
+  useEffect(() => {
+    // this avoids getting an unexpected previous participant in this particular edge case:
+    // - the user opens a newdle they created with a specific participant link
+    // - they go to "my newdles", and then open that same newdle from there
+    // - they switch to the answer view using the buttons on top
+    // this would now use the stored participant code, even though after coming from there
+    // you would expect to get the participant code linked to your user (if you are a participant),
+    // or the usual "enter name" form...
+    dispatch(clearParticipantCodes());
+  }, [dispatch]);
 
   let content;
   if (loading || newdles === null) {

--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -5,12 +5,17 @@ import {useHistory} from 'react-router';
 import {useRouteMatch} from 'react-router-dom';
 import {Container, Icon, Button, Popup} from 'semantic-ui-react';
 import {getUserInfo} from '../selectors';
+import {getStoredParticipantCodeForNewdle} from '../answerSelectors';
 import styles from './NewdleTitle.module.scss';
 
 export default function NewdleTitle({title, author, creatorUid, finished, code, isPrivate}) {
   const userInfo = useSelector(getUserInfo);
+  const participantCode = useSelector(state => getStoredParticipantCodeForNewdle(state, code));
   const history = useHistory();
   const isSummary = !!useRouteMatch({path: '/newdle/:code/summary'});
+
+  const summaryURL = `/newdle/${code}/summary`;
+  const answerURL = `/newdle/${code}/${participantCode || ''}`;
 
   return (
     <Container text className={styles['box']}>
@@ -31,7 +36,7 @@ export default function NewdleTitle({title, author, creatorUid, finished, code, 
                   <Button
                     icon
                     active={!isSummary}
-                    onClick={() => (isSummary ? history.push(`/newdle/${code}/`) : null)}
+                    onClick={() => (isSummary ? history.push(answerURL) : null)}
                     disabled={finished}
                   >
                     <Icon name="calendar plus outline" />
@@ -45,7 +50,7 @@ export default function NewdleTitle({title, author, creatorUid, finished, code, 
                   <Button
                     icon
                     active={isSummary}
-                    onClick={() => (!isSummary ? history.push(`/newdle/${code}/summary`) : null)}
+                    onClick={() => (!isSummary ? history.push(summaryURL) : null)}
                   >
                     <Icon name="tasks" />
                   </Button>

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -22,7 +22,12 @@ import {
   hasBusyTimes,
 } from '../../answerSelectors';
 import {getUserInfo} from '../../selectors';
-import {chooseAllAvailable, fetchBusyTimesForAnswer, fetchParticipant} from '../../actions';
+import {
+  chooseAllAvailable,
+  fetchBusyTimesForAnswer,
+  fetchParticipant,
+  setParticipantCode,
+} from '../../actions';
 import client from '../../client';
 import {usePageTitle} from '../../util/hooks';
 import styles from './answer.module.scss';
@@ -120,6 +125,9 @@ export default function AnswerPage() {
   useEffect(() => {
     if (newdle && (participantCode || user) && !submitting) {
       dispatch(fetchParticipant(newdle.code, participantCode || null));
+      if (participantCode) {
+        dispatch(setParticipantCode(newdle.code, participantCode));
+      }
     }
   }, [newdle, user, participantCode, dispatch, submitting]);
 

--- a/newdle/client/src/reducers/answer.js
+++ b/newdle/client/src/reducers/answer.js
@@ -9,6 +9,8 @@ import {
   SET_ANSWER_ACTIVE_DATE,
   SET_ANSWER_BUSY_TIMES,
   PARTICIPANT_RECEIVED,
+  SET_PARTICIPANT_CODE,
+  CLEAR_PARTICIPANT_CODES,
 } from '../actions';
 
 export default combineReducers({
@@ -83,6 +85,20 @@ export default combineReducers({
         return action.participant;
       case ABORT_ANSWERING:
         return null;
+      default:
+        return state;
+    }
+  },
+
+  participantCodes: (state = {}, action) => {
+    switch (action.type) {
+      case SET_PARTICIPANT_CODE:
+        return {
+          ...state,
+          [action.newdleCode]: action.participantCode,
+        };
+      case CLEAR_PARTICIPANT_CODES:
+        return {};
       default:
         return state;
     }


### PR DESCRIPTION
This is important when not logged in or viewing another participant, since otherwise going to the summary and back (using the button in newdle, not the browser's back button) would result in an empty participant code and thus your old answer not being displayed anymore.