### PR TITLE
Displaying timezone on answers page

### DIFF
--- a/newdle/api.py
+++ b/newdle/api.py
@@ -205,6 +205,7 @@ def _get_busy_times(date, tz, uid):
         [
             ['{:02}:{:02}'.format(*r[0]), '{:02}:{:02}'.format(*r[1])]
             for r in merged_ranges
+            if r[0] != r[1]
         ]
     )
 

--- a/newdle/api.py
+++ b/newdle/api.py
@@ -193,10 +193,10 @@ def get_participant_busy_times(date, code, tz, participant_code=None):
     ).first_or_404('Specified participant does not exist')
     if participant.auth_uid is None:
         abort(422, messages={'participant_code': ['Participant is an unknown user']})
-    targetTz = timezone(tz)
-    newdleTz = timezone(participant.newdle.timezone)
+    target_tz = timezone(tz)
+    newdle_tz = timezone(participant.newdle.timezone)
     if not any(
-        date == change_dt_timezone(ts, newdleTz, targetTz).date()
+        date == change_dt_timezone(ts, newdle_tz, target_tz).date()
         for ts in participant.newdle.timeslots
     ):
         abort(422, messages={'date': ['Date has no timeslots']})

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -19,26 +19,29 @@ export const getNumberOfTimeslots = createSelector(
   getNewdleTimeslots,
   slots => slots.length
 );
-export const getCalendarDates = createSelector(
+export const getLocalNewdleTimeslots = createSelector(
   getNewdleTimeslots,
   getUserTimezone,
   getNewdleTimezone,
   (timeslots, userTz, newdleTz) =>
-    _.uniq(
-      timeslots.map(timeslot =>
-        serializeDate(
-          toMoment(timeslot, moment.HTML5_FMT.DATETIME_LOCAL, newdleTz),
-          moment.HTML5_FMT.DATE,
-          userTz
-        )
+    timeslots.map(timeslot =>
+      serializeDate(
+        toMoment(timeslot, moment.HTML5_FMT.DATETIME_LOCAL, newdleTz),
+        moment.HTML5_FMT.DATETIME_LOCAL,
+        userTz
       )
+    )
+);
+export const getCalendarDates = createSelector(
+  getLocalNewdleTimeslots,
+  timeslots =>
+    _.uniq(
+      timeslots.map(timeslot => serializeDate(toMoment(timeslot, moment.HTML5_FMT.DATETIME_LOCAL)))
     )
 );
 
 export const getActiveDate = state =>
-  state.answer.calendarActiveDate ||
-  getCalendarDates(state)[0] ||
-  serializeDate(moment(), moment.HTML5_FMT.DATE, getUserTimezone(state));
+  state.answer.calendarActiveDate || getCalendarDates(state)[0] || serializeDate(moment());
 
 /** Whether busy times are known */
 export const hasBusyTimes = state => state.answer.busyTimes !== null;

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import {createSelector} from 'reselect';
 import {overlaps, serializeDate, toMoment} from './util/date';
+import {getUserTimezone} from './selectors';
 
 export const getNewdle = state => state.answer.newdle;
 export const getHandpickedAnswers = state => state.answer.answers;
@@ -20,13 +21,24 @@ export const getNumberOfTimeslots = createSelector(
 );
 export const getCalendarDates = createSelector(
   getNewdleTimeslots,
-  timeslots =>
+  getUserTimezone,
+  getNewdleTimezone,
+  (timeslots, userTz, newdleTz) =>
     _.uniq(
-      timeslots.map(timeslot => serializeDate(toMoment(timeslot, moment.HTML5_FMT.DATETIME_LOCAL)))
+      timeslots.map(timeslot =>
+        serializeDate(
+          toMoment(timeslot, moment.HTML5_FMT.DATETIME_LOCAL, newdleTz),
+          moment.HTML5_FMT.DATE,
+          userTz
+        )
+      )
     )
 );
+
 export const getActiveDate = state =>
-  state.answer.calendarActiveDate || getCalendarDates(state)[0] || serializeDate(moment());
+  state.answer.calendarActiveDate ||
+  getCalendarDates(state)[0] ||
+  serializeDate(moment(), moment.HTML5_FMT.DATE, getUserTimezone(state));
 
 /** Whether busy times are known */
 export const hasBusyTimes = state => state.answer.busyTimes !== null;

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -32,6 +32,12 @@ export const getLocalNewdleTimeslots = createSelector(
       )
     )
 );
+/** A mapping from user-tz timeslots to newdle-tz timeslots */
+const getLocalNewdleTimeslotsMap = createSelector(
+  getNewdleTimeslots,
+  getLocalNewdleTimeslots,
+  (timeslots, localTimeslots) => _.zipObject(localTimeslots, timeslots)
+);
 export const getCalendarDates = createSelector(
   getLocalNewdleTimeslots,
   timeslots =>
@@ -81,17 +87,17 @@ export const isAllAvailableSelectedExplicitly = state => state.answer.allAvailab
 /** All time slots during which the person is free */
 const getFreeTimeslots = createSelector(
   getFlatBusyTimes,
-  getNewdleTimeslots,
+  getLocalNewdleTimeslotsMap,
   getNewdleDuration,
-  (busyTimes, timeslots, duration) => {
+  (busyTimes, timeslotMap, duration) => {
     busyTimes = busyTimes.map(pair => pair.map(t => toMoment(t, moment.HTML5_FMT.DATETIME_LOCAL)));
-    timeslots = timeslots.map(t => [
+    const localTimeslots = Object.keys(timeslotMap).map(t => [
       toMoment(t, moment.HTML5_FMT.DATETIME_LOCAL),
       toMoment(t, moment.HTML5_FMT.DATETIME_LOCAL).add(duration, 'm'),
     ]);
-    return timeslots
+    return localTimeslots
       .filter(ts => !busyTimes.some(bt => overlaps(ts, bt)))
-      .map(([start]) => serializeDate(start, moment.HTML5_FMT.DATETIME_LOCAL))
+      .map(([start]) => timeslotMap[serializeDate(start, moment.HTML5_FMT.DATETIME_LOCAL)])
       .sort();
   }
 );

--- a/newdle/client/src/components/ParticipantTable.js
+++ b/newdle/client/src/components/ParticipantTable.js
@@ -6,7 +6,12 @@ import {Radio, Icon, Label, Table} from 'semantic-ui-react';
 import AvailabilityRing from './AvailabilityRing';
 import {serializeDate, toMoment} from '../util/date';
 import {useIsMobile} from 'src/util/hooks';
-import {getNewdleDuration, getNumberOfParticipants, getParticipantAvailability} from '../selectors';
+import {
+  getNewdleDuration,
+  getNewdleTimezone,
+  getNumberOfParticipants,
+  getParticipantAvailability,
+} from '../selectors';
 import styles from './ParticipantTable.module.scss';
 
 const MAX_PARTICIPANTS_SHOWN = 4;
@@ -69,6 +74,7 @@ function AvailabilityRow({
   children,
 }) {
   const numberOfParticipants = useSelector(getNumberOfParticipants);
+  const newdleTimezone = useSelector(getNewdleTimezone);
   const duration = useSelector(getNewdleDuration);
   const startTime = toMoment(startDt, 'YYYY-MM-DDTHH:mm');
 
@@ -109,6 +115,7 @@ function AvailabilityRow({
             <div>
               <div className={styles['date']}>{startTime.format('D MMM')}</div>
               <div className={styles['time']}>{formatMeetingTime(startTime, duration)}</div>
+              <div className={styles['timezone']}>{newdleTimezone}</div>
             </div>
             {!finalized && isCreator && <Radio name="slot-id" value={startDt} checked={active} />}
           </div>
@@ -116,6 +123,7 @@ function AvailabilityRow({
           <>
             <div className={styles['date']}>{startTime.format('D MMM')}</div>
             <div className={styles['time']}>{formatMeetingTime(startTime, duration)}</div>
+            <div className={styles['timezone']}>({newdleTimezone})</div>
           </>
         )}
       </Table.Cell>

--- a/newdle/client/src/components/ParticipantTable.module.scss
+++ b/newdle/client/src/components/ParticipantTable.module.scss
@@ -35,6 +35,12 @@
       color: gray;
     }
 
+    .timezone {
+      font-size: 10px;
+      font-weight: normal;
+      color: gray;
+    }
+
     .available-participants {
       .wrapper {
         display: flex;

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -150,9 +150,10 @@ export default function AnswerPage() {
 
   useEffect(() => {
     if ((participantCode && !participantUnknown) || (!participantCode && user)) {
-      dispatch(fetchBusyTimesForAnswer(newdleCode, participantCode || null, dates, newdleTz));
+      // Fetching busy times for user's timezone so no timezone conversion needed later
+      dispatch(fetchBusyTimesForAnswer(newdleCode, participantCode || null, dates, userTz));
     }
-  }, [dates, newdleCode, participantCode, participantUnknown, user, newdleTz, dispatch]);
+  }, [dates, newdleCode, participantCode, participantUnknown, user, userTz, dispatch]);
 
   if (!newdle || (participantCode && !participant)) {
     return null;

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -101,7 +101,7 @@ export default function AnswerPage() {
   const participantUnknown = useSelector(isParticipantUnknown);
   const participantAnswersChanged = useSelector(haveParticipantAnswersChanged);
   const busyTimesLoaded = useSelector(hasBusyTimes);
-  const tz = useSelector(getNewdleTimezone);
+  const newdleTz = useSelector(getNewdleTimezone);
   const userTz = useSelector(getUserTimezone);
   usePageTitle(newdle && newdle.title, true);
 
@@ -150,9 +150,9 @@ export default function AnswerPage() {
 
   useEffect(() => {
     if ((participantCode && !participantUnknown) || (!participantCode && user)) {
-      dispatch(fetchBusyTimesForAnswer(newdleCode, participantCode || null, dates, tz));
+      dispatch(fetchBusyTimesForAnswer(newdleCode, participantCode || null, dates, newdleTz));
     }
-  }, [dates, newdleCode, participantCode, participantUnknown, user, tz, dispatch]);
+  }, [dates, newdleCode, participantCode, participantUnknown, user, newdleTz, dispatch]);
 
   if (!newdle || (participantCode && !participant)) {
     return null;
@@ -211,7 +211,10 @@ export default function AnswerPage() {
                 />
               </Segment>
             )}
-            <Header as="h3" className={styles.date}>
+            <Header as="h4" className={styles.date}>
+              Newdle timezone: {newdleTz}
+            </Header>
+            <Header as="h4" className={styles.date}>
               Displayed timezone: {userTz}
             </Header>
           </Grid.Column>

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -1,14 +1,4 @@
-import {
-  Button,
-  Checkbox,
-  Container,
-  Grid,
-  Icon,
-  Input,
-  Message,
-  Segment,
-  Header,
-} from 'semantic-ui-react';
+import {Button, Checkbox, Container, Grid, Icon, Input, Message, Segment} from 'semantic-ui-react';
 import React, {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useParams} from 'react-router-dom';
@@ -212,12 +202,12 @@ export default function AnswerPage() {
                 />
               </Segment>
             )}
-            <Header as="h4" className={styles.date}>
-              Newdle timezone: {newdleTz}
-            </Header>
-            <Header as="h4" className={styles.date}>
-              Displayed timezone: {userTz}
-            </Header>
+            <div className={styles.timezone}>
+              <span className={styles['timezone-title']}>Newdle timezone:</span> {newdleTz}
+            </div>
+            <div className={styles.timezone}>
+              <span className={styles['timezone-title']}>Displayed timezone:</span> {userTz}
+            </div>
           </Grid.Column>
           <Grid.Column computer={11} tablet={8}>
             <Calendar />

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -1,4 +1,14 @@
-import {Button, Checkbox, Container, Grid, Icon, Input, Message, Segment} from 'semantic-ui-react';
+import {
+  Button,
+  Checkbox,
+  Container,
+  Grid,
+  Icon,
+  Input,
+  Message,
+  Segment,
+  Header,
+} from 'semantic-ui-react';
 import React, {useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {useParams} from 'react-router-dom';
@@ -21,7 +31,7 @@ import {
   haveParticipantAnswersChanged,
   hasBusyTimes,
 } from '../../answerSelectors';
-import {getUserInfo} from '../../selectors';
+import {getUserInfo, getUserTimezone} from '../../selectors';
 import {
   chooseAllAvailable,
   fetchBusyTimesForAnswer,
@@ -92,6 +102,7 @@ export default function AnswerPage() {
   const participantAnswersChanged = useSelector(haveParticipantAnswersChanged);
   const busyTimesLoaded = useSelector(hasBusyTimes);
   const tz = useSelector(getNewdleTimezone);
+  const userTz = useSelector(getUserTimezone);
   usePageTitle(newdle && newdle.title, true);
 
   const [submitAnswer, submitting, , submitResult] = participantCode
@@ -200,6 +211,9 @@ export default function AnswerPage() {
                 />
               </Segment>
             )}
+            <Header as="h3" className={styles.date}>
+              Displayed timezone: {userTz}
+            </Header>
           </Grid.Column>
           <Grid.Column computer={11} tablet={8}>
             <Calendar />

--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -202,6 +202,12 @@ Hours.defaultProps = {
   hourStep: 2,
 };
 
+function getLocalHour(hour, newdleTz, userTz) {
+  let moment = toMoment(hour, 'HH', newdleTz);
+  let localHour = serializeDate(moment, 'HH', userTz);
+  return parseInt(localHour);
+}
+
 export default function Calendar() {
   const answers = useSelector(getAnswers);
   const timeSlots = useSelector(getNewdleTimeslots);
@@ -222,26 +228,28 @@ export default function Calendar() {
   const format = DEFAULT_FORMAT;
   const input = {
     timeSlots,
-    busyTimes,
     defaultHourSpan,
     defaultMinHour: MIN_HOUR,
     defaultMaxHour: MAX_HOUR,
     duration,
     format,
-    newdleTz,
-    userTz,
   };
   const [minHour, maxHour] = getHourSpan(input);
+  console.log([minHour, maxHour]);
+  const minHourLocal = getLocalHour(minHour, newdleTz, userTz);
+  const maxHourLocal = getLocalHour(maxHour, newdleTz, userTz);
+  console.log([minHourLocal, maxHourLocal]);
   const optionsByDay = calculateOptionsPositions(
     timeSlots,
     duration,
-    minHour,
-    maxHour,
+    minHourLocal,
+    maxHourLocal,
     answers,
     newdleTz,
     userTz
   );
-  const busyByDay = calculateBusyPositions(busyTimes, minHour, maxHour, newdleTz, userTz);
+  console.log(busyTimes);
+  const busyByDay = calculateBusyPositions(busyTimes, minHourLocal, maxHourLocal, newdleTz, userTz);
   const activeDateIndex = optionsByDay.findIndex(({date: timeSlotDate}) =>
     toMoment(timeSlotDate, HTML5_FMT.DATE, newdleTz)
       .tz(userTz)
@@ -253,7 +261,7 @@ export default function Calendar() {
     <Grid className={styles.calendar}>
       <Grid.Row>
         <Grid.Column width={1}>
-          <Hours minHour={minHour} maxHour={maxHour} />
+          <Hours minHour={minHourLocal} maxHour={maxHourLocal} />
         </Grid.Column>
         <DayCarousel
           numberOfVisible={numDaysVisible}

--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -103,9 +103,9 @@ function getSlotProps(slot, duration, minHour, maxHour, answer, newdleTz, userTz
   const answerProps = getAnswerProps(slot, answer);
 
   const startMomentLocal = toMoment(slot, DEFAULT_FORMAT, newdleTz).tz(userTz);
-  const startTimeLocal = serializeDate(startMomentLocal, 'HH:mm', userTz);
+  const startTimeLocal = serializeDate(startMomentLocal, 'H:mm', userTz);
   const endMomentLocal = startMomentLocal.clone().add(duration, 'm');
-  const endTimeLocal = serializeDate(endMomentLocal, 'HH:mm', userTz);
+  const endTimeLocal = serializeDate(endMomentLocal, 'H:mm', userTz);
 
   const height = calculateHeight(startMomentLocal, endMomentLocal, minHour, maxHour);
   const pos = calculatePosition(startMomentLocal, minHour, maxHour);
@@ -141,8 +141,8 @@ function getBusySlotProps(slot, minHour, maxHour) {
   const start = toMoment(startTime, 'HH:mm');
   const end = toMoment(endTime, 'HH:mm');
   return {
-    startTime,
-    endTime,
+    startTime: serializeDate(start, 'H:mm'),
+    endTime: serializeDate(end, 'H:mm'),
     height: calculateHeight(start, end, minHour, maxHour),
     pos: calculatePosition(start, minHour, maxHour),
     key: `${startTime}-${endTime}`,

--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -103,12 +103,14 @@ function getSlotProps(slot, duration, minHour, maxHour, answer, newdleTz, userTz
   const start = toMoment(slot, DEFAULT_FORMAT);
   const end = toMoment(start).add(duration, 'm');
   const answerProps = getAnswerProps(slot, answer);
-  const height = calculateHeight(start, end, minHour, maxHour);
 
-  let startMomentLocal = toMoment(slot, DEFAULT_FORMAT, newdleTz).tz(userTz);
-  const pos = calculatePosition(startMomentLocal, minHour, maxHour);
+  const startMomentLocal = toMoment(slot, DEFAULT_FORMAT, newdleTz).tz(userTz);
   const startTimeLocal = serializeDate(startMomentLocal, 'HH:mm', userTz);
-  const endTimeLocal = serializeDate(startMomentLocal.clone().add(duration, 'm'), 'HH:mm', userTz);
+  const endMomentLocal = startMomentLocal.clone().add(duration, 'm');
+  const endTimeLocal = serializeDate(endMomentLocal, 'HH:mm', userTz);
+
+  const height = calculateHeight(startMomentLocal, endMomentLocal, minHour, maxHour);
+  const pos = calculatePosition(startMomentLocal, minHour, maxHour);
 
   return {
     slot,
@@ -140,13 +142,13 @@ function calculateOptionsPositions(options, duration, minHour, maxHour, answers,
 
 function getBusySlotProps(slot, minHour, maxHour, date, newdleTz, userTz) {
   const [startTime, endTime] = slot;
-  const start = toMoment(startTime, 'HH:mm', newdleTz);
-  const end = toMoment(endTime, 'HH:mm', newdleTz);
+  const start = toMoment(startTime, 'HH:mm', newdleTz).tz(userTz);
+  const end = toMoment(endTime, 'HH:mm', newdleTz).tz(userTz);
 
   const startDatetime = toMoment([date, startTime].join('T'), DEFAULT_FORMAT, newdleTz).tz(userTz);
   const pos = calculatePosition(startDatetime, minHour, maxHour);
   const startTimeLocal = serializeDate(startDatetime, 'HH:mm', userTz);
-  const endTimeLocal = serializeDate(end.clone().tz(userTz), 'HH:mm', userTz);
+  const endTimeLocal = serializeDate(end, 'HH:mm', userTz);
 
   return {
     startTime,

--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -209,10 +209,10 @@ Hours.defaultProps = {
   hourStep: 2,
 };
 
-function getLocalHour(hour, newdleTz, userTz) {
-  let moment = toMoment(hour, 'HH', newdleTz);
-  let localHour = serializeDate(moment, 'HH', userTz);
-  return parseInt(localHour);
+function getLocalHour(hour, originalTz, localTz) {
+  let moment = toMoment(hour, 'HH', originalTz);
+  let localHour = serializeDate(moment, 'HH', localTz);
+  return parseInt(localHour) || 24;
 }
 
 export default function Calendar() {
@@ -236,8 +236,8 @@ export default function Calendar() {
   const input = {
     timeSlots,
     defaultHourSpan,
-    defaultMinHour: MIN_HOUR,
-    defaultMaxHour: MAX_HOUR,
+    defaultMinHour: getLocalHour(MIN_HOUR, userTz, newdleTz),
+    defaultMaxHour: getLocalHour(MAX_HOUR, userTz, newdleTz),
     duration,
     format,
   };

--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -105,22 +105,18 @@ function getSlotProps(slot, duration, minHour, maxHour, answer, newdleTz, userTz
   const answerProps = getAnswerProps(slot, answer);
   const height = calculateHeight(start, end, minHour, maxHour);
 
-  let startMomentForTimezone = toMoment(slot, DEFAULT_FORMAT, newdleTz).tz(userTz);
-  const pos = calculatePosition(startMomentForTimezone, minHour, maxHour);
-  const startForTimezone = serializeDate(startMomentForTimezone, 'HH:mm', userTz);
-  const endForTimezone = serializeDate(
-    startMomentForTimezone.clone().add(duration, 'm'),
-    'HH:mm',
-    userTz
-  );
+  let startMomentLocal = toMoment(slot, DEFAULT_FORMAT, newdleTz).tz(userTz);
+  const pos = calculatePosition(startMomentLocal, minHour, maxHour);
+  const startTimeLocal = serializeDate(startMomentLocal, 'HH:mm', userTz);
+  const endTimeLocal = serializeDate(startMomentLocal.clone().add(duration, 'm'), 'HH:mm', userTz);
 
   return {
     slot,
     startTime: serializeDate(start, 'HH:mm'),
     endTime: serializeDate(end, 'HH:mm'),
-    startForTimezone,
-    endForTimezone,
-    groupDateKey: startMomentForTimezone,
+    startTimeLocal,
+    endTimeLocal,
+    groupDateKey: startMomentLocal,
     height,
     pos,
     key: slot,
@@ -147,10 +143,10 @@ function getBusySlotProps(slot, minHour, maxHour, newdleTz, userTz) {
   const start = toMoment(startTime, 'HH:mm');
   const end = toMoment(endTime, 'HH:mm');
 
-  let startMomentForTimezone = toMoment(startTime, 'HH:mm', newdleTz).tz(userTz);
-  const pos = calculatePosition(startMomentForTimezone, minHour, maxHour);
-  const startForTimezone = serializeDate(startMomentForTimezone, 'HH:mm', userTz);
-  const endForTimezone = serializeDate(
+  let startMomentLocal = toMoment(startTime, 'HH:mm', newdleTz).tz(userTz);
+  const pos = calculatePosition(startMomentLocal, minHour, maxHour);
+  const startTimeLocal = serializeDate(startMomentLocal, 'HH:mm', userTz);
+  const endTimeLocal = serializeDate(
     toMoment(endTime, 'HH:mm', newdleTz).tz(userTz),
     'HH:mm',
     userTz
@@ -159,11 +155,11 @@ function getBusySlotProps(slot, minHour, maxHour, newdleTz, userTz) {
   return {
     startTime,
     endTime,
-    startForTimezone,
-    endForTimezone,
+    startTimeLocal,
+    endTimeLocal,
     height: calculateHeight(start, end, minHour, maxHour),
     pos,
-    key: `${startForTimezone}-${endForTimezone}`,
+    key: `${startTimeLocal}-${endTimeLocal}`,
   };
 }
 

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -10,11 +10,12 @@ import styles from './answer.module.scss';
 
 export default function DayTimeline({options, busySlots}) {
   const dispatch = useDispatch();
-  const date = serializeDate(toMoment(options.date, 'YYYY-MM-DD'), 'dddd D MMM');
+  // This date does not need to be timezone casted as we are only format correcting
+  const formattedDate = serializeDate(toMoment(options.date, 'YYYY-MM-DD'), 'dddd D MMM');
   return (
     <>
       <Header as="h3" className={styles.date}>
-        {date}
+        {formattedDate}
       </Header>
       <div className={styles['options-column']}>
         {options.optionGroups.map(group => {

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -46,7 +46,7 @@ export default function DayTimeline({options, busySlots}) {
               {...time}
               key={time.key}
               className={styles['busy-slot']}
-              tooltip={`${time.startTime} - ${time.endTime}`}
+              tooltip={`${time.startForTimezone} - ${time.endForTimezone}`}
             />
           ))}
       </div>

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -47,7 +47,7 @@ export default function DayTimeline({options, busySlots}) {
               {...time}
               key={time.key}
               className={styles['busy-slot']}
-              tooltip={`${time.startTimeLocal} - ${time.endTimeLocal}`}
+              tooltip={`${time.startTime} - ${time.endTime}`}
             />
           ))}
       </div>

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -46,7 +46,7 @@ export default function DayTimeline({options, busySlots}) {
               {...time}
               key={time.key}
               className={styles['busy-slot']}
-              tooltip={`${time.startForTimezone} - ${time.endForTimezone}`}
+              tooltip={`${time.startTimeLocal} - ${time.endTimeLocal}`}
             />
           ))}
       </div>

--- a/newdle/client/src/components/answer/Option.js
+++ b/newdle/client/src/components/answer/Option.js
@@ -8,13 +8,13 @@ export default function Option({
   onClick,
   className,
   styles: moreStyles,
-  startForTimezone,
-  endForTimezone,
+  startTimeLocal,
+  endTimeLocal,
 }) {
   return (
     <div className={`${styles.option} ${className}`} onClick={onClick} style={moreStyles}>
       <span className={styles.times}>
-        {startForTimezone} - {endForTimezone}
+        {startTimeLocal} - {endTimeLocal}
       </span>
       <Icon name={icon} />
     </div>
@@ -28,8 +28,8 @@ Option.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string.isRequired,
   styles: PropTypes.object,
-  startForTimezone: PropTypes.string.isRequired,
-  endForTimezone: PropTypes.string.isRequired,
+  startTimeLocal: PropTypes.string.isRequired,
+  endTimeLocal: PropTypes.string.isRequired,
 };
 
 Option.defaultProps = {

--- a/newdle/client/src/components/answer/Option.js
+++ b/newdle/client/src/components/answer/Option.js
@@ -1,17 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Icon} from 'semantic-ui-react';
-import {serializeDate, toMoment} from '../../util/date';
 import styles from './answer.module.scss';
 
-export default function Option({startTime, endTime, icon, onClick, className, styles: moreStyles}) {
-  const start = serializeDate(toMoment(startTime, 'H:mm'), 'H:mm');
-  const end = serializeDate(toMoment(endTime, 'H:mm'), 'H:mm');
-
+export default function Option({
+  icon,
+  onClick,
+  className,
+  styles: moreStyles,
+  startForTimezone,
+  endForTimezone,
+}) {
   return (
     <div className={`${styles.option} ${className}`} onClick={onClick} style={moreStyles}>
       <span className={styles.times}>
-        {start} - {end}
+        {startForTimezone} - {endForTimezone}
       </span>
       <Icon name={icon} />
     </div>
@@ -25,6 +28,8 @@ Option.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string.isRequired,
   styles: PropTypes.object,
+  startForTimezone: PropTypes.string.isRequired,
+  endForTimezone: PropTypes.string.isRequired,
 };
 
 Option.defaultProps = {

--- a/newdle/client/src/components/answer/Option.js
+++ b/newdle/client/src/components/answer/Option.js
@@ -3,18 +3,11 @@ import PropTypes from 'prop-types';
 import {Icon} from 'semantic-ui-react';
 import styles from './answer.module.scss';
 
-export default function Option({
-  icon,
-  onClick,
-  className,
-  styles: moreStyles,
-  startTimeLocal,
-  endTimeLocal,
-}) {
+export default function Option({icon, onClick, className, styles: moreStyles, startTime, endTime}) {
   return (
     <div className={`${styles.option} ${className}`} onClick={onClick} style={moreStyles}>
       <span className={styles.times}>
-        {startTimeLocal} - {endTimeLocal}
+        {startTime} - {endTime}
       </span>
       <Icon name={icon} />
     </div>
@@ -28,8 +21,6 @@ Option.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string.isRequired,
   styles: PropTypes.object,
-  startTimeLocal: PropTypes.string.isRequired,
-  endTimeLocal: PropTypes.string.isRequired,
 };
 
 Option.defaultProps = {

--- a/newdle/client/src/components/answer/Option.js
+++ b/newdle/client/src/components/answer/Option.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {Icon} from 'semantic-ui-react';
 import styles from './answer.module.scss';
 
-export default function Option({icon, onClick, className, styles: moreStyles, startTime, endTime}) {
+export default function Option({startTime, endTime, icon, onClick, className, styles: moreStyles}) {
   return (
     <div className={`${styles.option} ${className}`} onClick={onClick} style={moreStyles}>
       <span className={styles.times}>

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -203,3 +203,12 @@
 .on-behalf {
   color: $purple;
 }
+
+.timezone {
+  margin: 10px;
+  text-align: center;
+
+  .timezone-title {
+    font-weight: bold;
+  }
+}

--- a/newdle/client/src/components/creation/timeslots/Timeline.js
+++ b/newdle/client/src/components/creation/timeslots/Timeline.js
@@ -71,7 +71,7 @@ function getCandidateSlotProps(startTime, duration, minHour, maxHour) {
   const endTime = toMoment(startTime, DEFAULT_TIME_FORMAT)
     .add(duration, 'm')
     .format(DEFAULT_TIME_FORMAT);
-  return getSlotProps(startTime, endTime, minHour, maxHour, duration);
+  return getSlotProps(startTime, endTime, minHour, maxHour);
 }
 
 /**

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -15,7 +15,7 @@ export const isAcquiringToken = state => !!state.auth.acquiringToken;
 
 // user
 export const getUserInfo = state => state.user;
-export const getUserTimezone = _state => moment.tz.guess();
+export const getUserTimezone = () => moment.tz.guess();
 
 // creation
 export const getCreationCalendarDates = state => Object.keys(state.creation.timeslots);

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -15,6 +15,7 @@ export const isAcquiringToken = state => !!state.auth.acquiringToken;
 
 // user
 export const getUserInfo = state => state.user;
+export const getUserTimezone = state => (state.user && state.user.timezone) || moment.tz.guess();
 
 // creation
 export const getCreationCalendarDates = state => Object.keys(state.creation.timeslots);

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -84,6 +84,7 @@ export const getCreatedNewdle = state => state.creation.createdNewdle;
 
 // newdle
 export const getNewdle = state => state.newdle;
+export const getNewdleTimezone = state => state.newdle && state.newdle.timezone;
 export const getNewdleTimeslots = state => (state.newdle && state.newdle.timeslots) || [];
 export const getNewdleDuration = state => state.newdle && state.newdle.duration;
 export const getNewdleParticipants = state => (state.newdle && state.newdle.participants) || [];

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -15,7 +15,7 @@ export const isAcquiringToken = state => !!state.auth.acquiringToken;
 
 // user
 export const getUserInfo = state => state.user;
-export const getUserTimezone = state => (state.user && state.user.timezone) || moment.tz.guess();
+export const getUserTimezone = _state => moment.tz.guess();
 
 // creation
 export const getCreationCalendarDates = state => Object.keys(state.creation.timeslots);

--- a/newdle/client/src/util/date.js
+++ b/newdle/client/src/util/date.js
@@ -15,43 +15,15 @@ export function overlaps([start1, end1], [start2, end2]) {
 }
 
 export function getHourSpan(input) {
-  const {
-    timeSlots,
-    busyTimes,
-    defaultHourSpan,
-    defaultMinHour,
-    defaultMaxHour,
-    duration,
-    format,
-    newdleTz,
-    userTz,
-  } = input;
-  let timeSlotsMoment = [];
-  if (userTz && newdleTz) {
-    timeSlotsMoment = timeSlots.map(c => toMoment(c, format, newdleTz).tz(userTz));
-    Object.values(busyTimes).forEach(times =>
-      times.forEach(spans =>
-        spans.forEach(c => timeSlotsMoment.push(toMoment(c, 'HH:mm', newdleTz).tz(userTz)))
-      )
-    );
-  } else {
-    timeSlotsMoment = timeSlots.map(c => toMoment(c, format));
-  }
+  const {timeSlots, defaultHourSpan, defaultMinHour, defaultMaxHour, duration, format} = input;
+  const timeSlotsMoment = timeSlots.map(c => toMoment(c, format));
   const minTimelineHour = Math.min(...timeSlotsMoment.map(timeSlot => timeSlot.hour()));
-
-  let maxTimeQuery = null;
-  if (userTz && newdleTz) {
-    maxTimeQuery = moment.max(
-      timeSlotsMoment.map(timeSlot =>
-        moment.tz({hour: timeSlot.hour(), minutes: timeSlot.minutes()}, newdleTz).tz(userTz)
-      )
-    );
-  } else {
-    maxTimeQuery = moment.max(
+  const maxTimeline = moment
+    .max(
       timeSlotsMoment.map(timeSlot => moment({hour: timeSlot.hour(), minutes: timeSlot.minutes()}))
-    );
-  }
-  const maxTimeline = maxTimeQuery.clone().add(duration, 'm');
+    )
+    .clone()
+    .add(duration, 'm');
 
   const spansOverTwoDays =
     timeSlotsMoment.find(

--- a/newdle/client/src/util/date.js
+++ b/newdle/client/src/util/date.js
@@ -2,12 +2,12 @@ import moment, {HTML5_FMT} from 'moment';
 
 export const DEFAULT_TIME_FORMAT = 'HH:mm';
 
-export function toMoment(date, format = null) {
-  return date ? moment(date, format) : null;
+export function toMoment(date, format = null, timezone = null) {
+  return date ? moment.tz(date, format, timezone) : null;
 }
 
-export function serializeDate(date, format = HTML5_FMT.DATE) {
-  return moment(date).format(format);
+export function serializeDate(date, format = HTML5_FMT.DATE, timezone = null) {
+  return moment.tz(date, timezone).format(format);
 }
 
 export function overlaps([start1, end1], [start2, end2]) {
@@ -15,15 +15,43 @@ export function overlaps([start1, end1], [start2, end2]) {
 }
 
 export function getHourSpan(input) {
-  const {timeSlots, defaultHourSpan, defaultMinHour, defaultMaxHour, duration, format} = input;
-  const timeSlotsMoment = timeSlots.map(c => toMoment(c, format));
+  const {
+    timeSlots,
+    busyTimes,
+    defaultHourSpan,
+    defaultMinHour,
+    defaultMaxHour,
+    duration,
+    format,
+    newdleTz,
+    userTz,
+  } = input;
+  let timeSlotsMoment = [];
+  if (userTz && newdleTz) {
+    timeSlotsMoment = timeSlots.map(c => toMoment(c, format, newdleTz).tz(userTz));
+    Object.values(busyTimes).forEach(times =>
+      times.forEach(spans =>
+        spans.forEach(c => timeSlotsMoment.push(toMoment(c, 'HH:mm', newdleTz).tz(userTz)))
+      )
+    );
+  } else {
+    timeSlotsMoment = timeSlots.map(c => toMoment(c, format));
+  }
   const minTimelineHour = Math.min(...timeSlotsMoment.map(timeSlot => timeSlot.hour()));
-  const maxTimeline = moment
-    .max(
+
+  let maxTimeQuery = null;
+  if (userTz && newdleTz) {
+    maxTimeQuery = moment.max(
+      timeSlotsMoment.map(timeSlot =>
+        moment.tz({hour: timeSlot.hour(), minutes: timeSlot.minutes()}, newdleTz).tz(userTz)
+      )
+    );
+  } else {
+    maxTimeQuery = moment.max(
       timeSlotsMoment.map(timeSlot => moment({hour: timeSlot.hour(), minutes: timeSlot.minutes()}))
-    )
-    .clone()
-    .add(duration, 'm');
+    );
+  }
+  const maxTimeline = maxTimeQuery.clone().add(duration, 'm');
 
   const spansOverTwoDays =
     timeSlotsMoment.find(

--- a/newdle/client/src/util/date.js
+++ b/newdle/client/src/util/date.js
@@ -10,7 +10,8 @@ export function toMoment(date, format = null, tz = null) {
 }
 
 export function serializeDate(date, format = HTML5_FMT.DATE, tz = null) {
-  return (tz ? moment.tz(date, tz) : moment(date)).format(format);
+  const dateMoment = tz ? moment.tz(date, tz) : moment(date);
+  return dateMoment.format(format);
 }
 
 export function overlaps([start1, end1], [start2, end2]) {
@@ -48,14 +49,6 @@ export function getHourSpan(input) {
   } else {
     return [defaultMinHour, defaultMaxHour];
   }
-}
-
-export function getLocalHourSpan(input) {
-  const {timeSlots, newdleTz, userTz} = input;
-  input['timeSlots'] = timeSlots.map(c =>
-    serializeDate(toMoment(c, HTML5_FMT.DATETIME_LOCAL, newdleTz), HTML5_FMT.DATETIME_LOCAL, userTz)
-  );
-  return getHourSpan(input);
 }
 
 export function hourRange(start, end, step = 1, extendToNextDay = true) {

--- a/newdle/client/src/util/date.js
+++ b/newdle/client/src/util/date.js
@@ -2,12 +2,15 @@ import moment, {HTML5_FMT} from 'moment';
 
 export const DEFAULT_TIME_FORMAT = 'HH:mm';
 
-export function toMoment(date, format = null, timezone = null) {
-  return date ? moment.tz(date, format, timezone) : null;
+export function toMoment(date, format = null, tz = null) {
+  if (!date) {
+    return null;
+  }
+  return tz ? moment.tz(date, format, tz) : moment(date, format);
 }
 
-export function serializeDate(date, format = HTML5_FMT.DATE, timezone = null) {
-  return moment.tz(date, timezone).format(format);
+export function serializeDate(date, format = HTML5_FMT.DATE, tz = null) {
+  return (tz ? moment.tz(date, tz) : moment(date)).format(format);
 }
 
 export function overlaps([start1, end1], [start2, end2]) {
@@ -45,6 +48,14 @@ export function getHourSpan(input) {
   } else {
     return [defaultMinHour, defaultMaxHour];
   }
+}
+
+export function getLocalHourSpan(input) {
+  const {timeSlots, newdleTz, userTz} = input;
+  input['timeSlots'] = timeSlots.map(c =>
+    serializeDate(toMoment(c, HTML5_FMT.DATETIME_LOCAL, newdleTz), HTML5_FMT.DATETIME_LOCAL, userTz)
+  );
+  return getHourSpan(input);
 }
 
 export function hourRange(start, end, step = 1, extendToNextDay = true) {

--- a/newdle/core/util.py
+++ b/newdle/core/util.py
@@ -22,6 +22,10 @@ def format_dt(dt):
     return dt.strftime(DATETIME_FORMAT)
 
 
+def change_dt_timezone(dt, from_tz, to_tz):
+    return from_tz.localize(dt).astimezone(to_tz)
+
+
 def range_union(ranges):
     """Take a list of (H, M) tuples and merge any overlapping intervals."""
     results = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Jinja2==2.10.3
 marshmallow-enum==1.5.1
 marshmallow-sqlalchemy==0.19.0
 marshmallow==3.2.1
-psycopg2-binary==2.8.4
+psycopg2==2.8.4
 python-dotenv==0.10.3
 pytz
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Jinja2==2.10.3
 marshmallow-enum==1.5.1
 marshmallow-sqlalchemy==0.19.0
 marshmallow==3.2.1
-psycopg2==2.8.4
+psycopg2-binary==2.8.4
 python-dotenv==0.10.3
 pytz
 requests==2.22.0


### PR DESCRIPTION
## Preview:

<img width="1199" alt="Screen Shot 2020-09-08 at 21 54 43" src="https://user-images.githubusercontent.com/21281337/92542478-3bd5d980-f21f-11ea-9a76-235f3b41ee3a.png">
<img width="1227" alt="Screen Shot 2020-09-02 at 23 37 10" src="https://user-images.githubusercontent.com/21281337/92065040-4272d580-ed75-11ea-9fb5-5e1e769914b3.png">


## Description:

Adding timezone functionality to the newdle answer page as mentioned on #208 . The display timezone used by default is the one obtained from the user's browser. Dates are kept both in the format received by the server and in a timezone sensitive format to show the user

## Todo:

- Active date marked on calendar seems to ignore user timezone, need to look more into it

## Checks:

- All tests pass ✅ 
- All linting rules pass ✅

## Manual testing:

Environment setup:

```
make
source ./.venv/bin/activate
make flask-server
make react-server
```

- Newdle with same timezone as user's has it's dates displayed without changes ✅
- Newdle with option 17:00 - 17:30 on CEST displays as 12:00 - 12:30 on Sao Paulo time ✅
- Newdle displays date correctly with 12 hour difference (e.g. 10:00 August 31st on Japan should be 22:00 August 30th on Sao Paulo) ✅
- Same 12 hour difference check for busy times ✅
- Active date on calendar matches event date correctly when 12 hour difference ✅
- Active date on calendar matches event date correctly when 12 hour difference ✅
- "Accept all options where I'm available" toggle highlights only the aforementioned slots ✅

## Questions:

N/A