### PR TITLE
Correctly handle timezones in random free-busy

### DIFF
--- a/newdle/core/util.py
+++ b/newdle/core/util.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, time
 from enum import Enum
 
 from flask import current_app
@@ -61,3 +61,21 @@ def check_user_signature(user_data, signature, fields=None):
     return signer.verify_signature(
         _get_signature_source_bytes(user_data, fields), signature.encode('ascii')
     )
+
+
+def find_overlap(day, start, end, tz):
+    """Find the overlap of a day with a datetime range.
+
+    :param day: the day to calculate overlap for (00:00 - 23:59)
+    :param start: the start ``datetime`` of the range (tz-aware)
+    :param end: the end ``datetime`` of the range (tz-aware)
+    :param tz: the timezone of reference
+    """
+    latest_start = max(
+        tz.localize(datetime.combine(day, time.min)), start.astimezone(tz)
+    )
+    earliest_end = min(tz.localize(datetime.combine(day, time.max)), end.astimezone(tz))
+    diff = (earliest_end - latest_start).days + 1
+    if diff > 0:
+        return latest_start.time(), earliest_end.time()
+    return None

--- a/newdle/providers/free_busy/exchange.py
+++ b/newdle/providers/free_busy/exchange.py
@@ -8,6 +8,8 @@ from exchangelib.errors import (
 )
 from flask import current_app
 
+from ...core.util import find_overlap
+
 
 TYPE_MAP = {'Busy': 'busy', 'Tentative': 'busy', 'OOF': 'busy'}
 
@@ -29,24 +31,6 @@ NON_STANDARD_TZS = {
     'Canada/Mountain': 'America/Edmonton',
     'Canada/Pacific': 'America/Vancouver',
 }
-
-
-def find_overlap(day, start, end, tz):
-    """Find the overlap of a day with a datetime range.
-
-    :param day: the day to calculate overlap for (00:00 - 23:59)
-    :param start: the start ``datetime`` of the range (tz-aware)
-    :param end: the end ``datetime`` of the range (tz-aware)
-    :param tz: the timezone of reference
-    """
-    latest_start = max(
-        tz.localize(datetime.combine(day, time.min)), start.astimezone(tz)
-    )
-    earliest_end = min(tz.localize(datetime.combine(day, time.max)), end.astimezone(tz))
-    diff = (earliest_end - latest_start).days + 1
-    if diff > 0:
-        return latest_start.time(), earliest_end.time()
-    return None
 
 
 def fetch_free_busy(date, tz, uid):

--- a/newdle/providers/free_busy/random.py
+++ b/newdle/providers/free_busy/random.py
@@ -1,26 +1,57 @@
-import datetime
+from datetime import datetime, time, timedelta
+from itertools import chain
 from random import Random
 
+import pytz
 
-def _to_tuple(t):
-    return (t.hour, t.minute)
+from ...core.util import find_overlap
 
 
 def fetch_free_busy(date, tz, uid):
+    # We have to include the day before/after since we may end up needing data
+    # from those days depending on the timezone
+    free_busy = list(
+        chain.from_iterable(
+            _generate_free_busy(date + timedelta(days=offset), uid)
+            for offset in (-1, 0, 1)
+        )
+    )
+
+    tzinfo = pytz.timezone(tz)
+    res = []
+    for (start, end) in free_busy:
+        overlap = find_overlap(date, start, end, tzinfo)
+        if overlap:
+            res.append(
+                (
+                    (overlap[0].hour, overlap[0].minute),
+                    (overlap[1].hour, overlap[1].minute),
+                )
+            )
+    return res
+
+
+def _generate_free_busy(date, uid):
     rnd = Random(date.isoformat() + uid)
     if rnd.randint(0, 1):
-        start = rnd.randint(5, 21)
-        end = rnd.randint(start + 1, 23)
-        start_time = _to_tuple(datetime.time(start))
-        end_time = _to_tuple(datetime.time(end))
-        return [[start_time, end_time]]
+        start = rnd.randint(4, 19)
+        end = rnd.randint(start + 1, 21)
+        start_dt = pytz.utc.localize(datetime.combine(date, time(start)))
+        end_dt = pytz.utc.localize(datetime.combine(date, time(end)))
+        return [(start_dt, end_dt)]
     else:
-        start = rnd.randint(7, 10)
+        start = rnd.randint(5, 8)
         end = rnd.randint(start + 1, start + 3)
-        start2 = rnd.randint(14, 16)
+        start2 = rnd.randint(12, 14)
         end2 = rnd.randint(start2 + 1, start2 + 5)
-        start_time = _to_tuple(datetime.time(start))
-        end_time = _to_tuple(datetime.time(end))
-        start_time2 = _to_tuple(datetime.time(start2))
-        end_time2 = _to_tuple(datetime.time(end2))
-        return [(start_time, end_time), (start_time2, end_time2)]
+        start_dt = pytz.utc.localize(
+            datetime.combine(date, time(start, 30 * rnd.randint(0, 1)))
+        )
+        end_dt = pytz.utc.localize(
+            datetime.combine(date, time(end, 30 * rnd.randint(0, 1)))
+        )
+        start_dt2 = pytz.utc.localize(
+            datetime.combine(date, time(start2, 15 * rnd.randint(0, 1)))
+        )
+        end_dt2 = pytz.utc.localize(datetime.combine(date, time(end2)))
+        return [(start_dt, end_dt), (start_dt2, end_dt2)]


### PR DESCRIPTION
Previously the random times were the same regardless of timezone, which is confusing when testing anything timezone-related. Now we have the same timezone logic as used for the real data from exchange.