### PR TITLE
Fixing SKIP_LOGIN's logout and multipass redirects

### DIFF
--- a/newdle/auth.py
+++ b/newdle/auth.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, current_app, render_template, url_for
+from flask import Blueprint, current_app, redirect, render_template, session, url_for
 
 from .core.auth import app_token_from_dummy, multipass
 
@@ -17,4 +17,8 @@ def login():
 
 @auth.route('/logout/')
 def logout():
-    return multipass.logout(url_for('index', _external=True), clear_session=True)
+    after_logout_url = url_for('index', _external=True)
+    if current_app.config['SKIP_LOGIN']:
+        session.clear()
+        return redirect(after_logout_url)
+    return multipass.logout(after_logout_url, clear_session=True)

--- a/newdle/core/app.py
+++ b/newdle/core/app.py
@@ -86,7 +86,8 @@ def create_app(config_override=None, use_env_config=True):
     _configure_app(app, from_env=use_env_config)
     if config_override:
         app.config.update(config_override)
-    _configure_multipass(app)
+    if not app.config['SKIP_LOGIN']:
+        _configure_multipass(app)
     _configure_db(app)
     _configure_errors(app)
     cache.init_app(app)


### PR DESCRIPTION
## Description:

This PR fixes two problems that appeared if using `SKIP_LOGIN = True` option without any multipass credentials in your `newdle.cfg`:

1. Couldn't sign in because I was getting redirected into `/login/newdle-sso` when trying to reach `/login/`, and newdle-sso would fail due to missing credentials
2. Couldn't sign out without getting flask error. This was simply because the logout endpoint had no logic reflecting `SKIP_LOGIN = True` option

## Todo:

N/A

## Checks:

- All tests pass ✅ 
- All linting rules pass ✅

## Manual testing:

Environment setup:

```
make
source ./.venv/bin/activate
make flask-server
make react-server
```
- `SKIP_LOGIN = True` on `newdle.cfg`
- No multipass credentials provided on `newdle.cfg`

1. I can sign in correctly into the test user ✅ 
2. I can sign out from the test user ✅ 

## Questions:

N/A