### PR TITLE
Create a comments field for participants

### DIFF
--- a/newdle/client/src/client.js
+++ b/newdle/client/src/client.js
@@ -188,13 +188,14 @@ class Client {
     }
   }
 
-  updateParticipantAnswers(newdleCode, participantCode, answers) {
+  updateParticipantAnswers(newdleCode, participantCode, answers, comment = '') {
     const params = {code: newdleCode, participant_code: participantCode};
     return this._request(flask`api.update_participant`(params), {
       anonymous: true,
       method: 'PATCH',
       body: JSON.stringify({
         answers,
+        comment,
       }),
     });
   }

--- a/newdle/client/src/components/ParticipantTable.js
+++ b/newdle/client/src/components/ParticipantTable.js
@@ -28,7 +28,7 @@ function ParticipantNames({participants}) {
   const statusColors = {available: 'green', ifneedbe: 'yellow', unavailable: 'red'};
 
   // eslint-disable-next-line react/prop-types
-  const renderName = ({name, status, id}) => (
+  const renderName = ({name, comment, status, id}) => (
     <div key={id} className={styles['user-element']}>
       <Icon
         name={status !== 'unavailable' ? 'checkmark' : 'close'}
@@ -38,6 +38,7 @@ function ParticipantNames({participants}) {
         inverted
       />
       {name}
+      <p className={styles['comment']}>{comment}</p>
     </div>
   );
 

--- a/newdle/client/src/components/ParticipantTable.module.scss
+++ b/newdle/client/src/components/ParticipantTable.module.scss
@@ -106,3 +106,9 @@
     }
   }
 }
+
+.comment {
+  font-size: 90%;
+  margin-top: 0.5rem;
+  color: gray;
+}

--- a/newdle/client/src/components/ParticipantTable.module.scss
+++ b/newdle/client/src/components/ParticipantTable.module.scss
@@ -58,6 +58,7 @@
           .user-element {
             display: flex;
             align-items: center;
+            flex-wrap: wrap;
             padding: 5px 0;
             margin-right: 5px;
           }
@@ -111,4 +112,5 @@
   font-size: 90%;
   margin-top: 0.5rem;
   color: gray;
+  flex-basis: 100%;
 }

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -89,7 +89,7 @@ export default function AnswerPage() {
   const participantHasAnswers = !!Object.keys(participantAnswers).length;
   const participant = useSelector(getParticipant);
   const [_comment, setComment] = useState(null);
-  const comment = _comment === null && participant ? participant.comment : _comment;
+  const comment = _comment === null && participant ? participant.comment : _comment || '';
   const participantUnknown = useSelector(isParticipantUnknown);
   const participantAnswersChanged = useSelector(haveParticipantAnswersChanged);
   const busyTimesLoaded = useSelector(hasBusyTimes);
@@ -230,7 +230,7 @@ export default function AnswerPage() {
             type="text"
             placeholder="Leave a comment..."
             className={styles['comment-submit']}
-            value={comment || ''}
+            value={comment}
             onChange={(__, {value}) => setComment(value)}
             action={!isSmallScreen}
           >

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -29,7 +29,7 @@ import {
   setParticipantCode,
 } from '../../actions';
 import client from '../../client';
-import {useIsMobile, useIsSmallScreen, usePageTitle} from '../../util/hooks';
+import {useIsSmallScreen, usePageTitle} from '../../util/hooks';
 import styles from './answer.module.scss';
 
 function ParticipantName({unknown, setName, onSubmit, disabled}) {
@@ -88,8 +88,8 @@ export default function AnswerPage() {
   const participantAnswers = useSelector(getParticipantAnswers);
   const participantHasAnswers = !!Object.keys(participantAnswers).length;
   const participant = useSelector(getParticipant);
-  const [_comment, setComment] = useState(undefined);
-  const comment = _comment == null && participant ? participant.comment : _comment;
+  const [_comment, setComment] = useState(null);
+  const comment = _comment === null && participant ? participant.comment : _comment;
   const participantUnknown = useSelector(isParticipantUnknown);
   const participantAnswersChanged = useSelector(haveParticipantAnswersChanged);
   const busyTimesLoaded = useSelector(hasBusyTimes);
@@ -243,7 +243,7 @@ export default function AnswerPage() {
                 submitting ||
                 !canSubmit ||
                 (participantCode && !participant) ||
-                (participantHasAnswers && !participantAnswersChanged && _comment == null)
+                (participantHasAnswers && !participantAnswersChanged && _comment === null)
               }
               loading={submitting}
               icon="send"

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -152,6 +152,12 @@ export default function AnswerPage() {
     return null;
   }
 
+  const submitDisabled =
+    submitting ||
+    !canSubmit ||
+    (participantCode && !participant) ||
+    (participantHasAnswers && !participantAnswersChanged && comment === participant.comment);
+
   if (newdle.final_dt) {
     return (
       <Container text>
@@ -232,6 +238,11 @@ export default function AnswerPage() {
             className={styles['comment-submit']}
             value={comment}
             onChange={(__, {value}) => setComment(value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !submitDisabled) {
+                answerNewdle();
+              }
+            }}
             action={!isSmallScreen}
           >
             <input />
@@ -239,14 +250,7 @@ export default function AnswerPage() {
               size="large"
               color={participantHasAnswers ? 'teal' : 'violet'}
               content={participantHasAnswers ? 'Update your answer' : 'Send your answer'}
-              disabled={
-                submitting ||
-                !canSubmit ||
-                (participantCode && !participant) ||
-                (participantHasAnswers &&
-                  !participantAnswersChanged &&
-                  comment === participant.comment)
-              }
+              disabled={submitDisabled}
               loading={submitting}
               icon="send"
               onClick={answerNewdle}

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -88,6 +88,8 @@ export default function AnswerPage() {
   const participantAnswers = useSelector(getParticipantAnswers);
   const participantHasAnswers = !!Object.keys(participantAnswers).length;
   const participant = useSelector(getParticipant);
+  const [_comment, setComment] = useState(undefined);
+  const comment = _comment == null && participant ? participant.comment : _comment;
   const participantUnknown = useSelector(isParticipantUnknown);
   const participantAnswersChanged = useSelector(haveParticipantAnswersChanged);
   const busyTimesLoaded = useSelector(hasBusyTimes);
@@ -113,14 +115,14 @@ export default function AnswerPage() {
         },
         // this is part 2: taking the newly created participant code and
         // updating the participant's answers based on it
-        ({code}) => client.updateParticipantAnswers(newdle.code, code, availabilityData)
+        ({code}) => client.updateParticipantAnswers(newdle.code, code, availabilityData, comment)
       );
 
   const canSubmit = (participantCode || user || name.length >= 2) && !submitting;
   const saved = submitResult !== null;
 
   const answerNewdle = () => {
-    submitAnswer(newdle.code, participantCode || name, availabilityData);
+    submitAnswer(newdle.code, participantCode || name, availabilityData, comment);
   };
 
   useEffect(() => {
@@ -223,22 +225,33 @@ export default function AnswerPage() {
               <em>No options chosen</em>
             )}
           </span>
-          <Button
-            size="large"
-            color={participantHasAnswers ? 'teal' : 'violet'}
-            content={participantHasAnswers ? 'Update your answer' : 'Send your answer'}
-            disabled={
-              submitting ||
-              !canSubmit ||
-              (participantCode && !participant) ||
-              (participantHasAnswers && !participantAnswersChanged)
-            }
-            loading={submitting}
-            icon="send"
-            onClick={() => {
-              answerNewdle();
+          <Input
+            type="text"
+            placeholder="Leave a comment..."
+            value={comment || ''}
+            onChange={(__, data) => {
+              setComment(data.value);
             }}
-          />
+            action
+          >
+            <input />
+            <Button
+              size="large"
+              color={participantHasAnswers ? 'teal' : 'violet'}
+              content={participantHasAnswers ? 'Update your answer' : 'Send your answer'}
+              disabled={
+                submitting ||
+                !canSubmit ||
+                (participantCode && !participant) ||
+                (participantHasAnswers && !participantAnswersChanged && _comment == null)
+              }
+              loading={submitting}
+              icon="send"
+              onClick={() => {
+                answerNewdle();
+              }}
+            />
+          </Input>
         </Grid.Row>
       </Grid>
     </div>

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -243,13 +243,13 @@ export default function AnswerPage() {
                 submitting ||
                 !canSubmit ||
                 (participantCode && !participant) ||
-                (participantHasAnswers && !participantAnswersChanged && _comment === null)
+                (participantHasAnswers &&
+                  !participantAnswersChanged &&
+                  comment === participant.comment)
               }
               loading={submitting}
               icon="send"
-              onClick={() => {
-                answerNewdle();
-              }}
+              onClick={answerNewdle}
             />
           </Input>
         </Grid.Row>

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -29,7 +29,7 @@ import {
   setParticipantCode,
 } from '../../actions';
 import client from '../../client';
-import {usePageTitle} from '../../util/hooks';
+import {useIsMobile, useIsSmallScreen, usePageTitle} from '../../util/hooks';
 import styles from './answer.module.scss';
 
 function ParticipantName({unknown, setName, onSubmit, disabled}) {
@@ -95,6 +95,7 @@ export default function AnswerPage() {
   const busyTimesLoaded = useSelector(hasBusyTimes);
   const newdleTz = useSelector(getNewdleTimezone);
   const userTz = useSelector(getUserTimezone);
+  const isSmallScreen = useIsSmallScreen();
   usePageTitle(newdle && newdle.title, true);
 
   const [submitAnswer, submitting, , submitResult] = participantCode
@@ -228,11 +229,12 @@ export default function AnswerPage() {
           <Input
             type="text"
             placeholder="Leave a comment..."
+            className={styles['comment-submit']}
             value={comment || ''}
             onChange={(__, data) => {
               setComment(data.value);
             }}
-            action
+            action={!isSmallScreen}
           >
             <input />
             <Button

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -231,9 +231,7 @@ export default function AnswerPage() {
             placeholder="Leave a comment..."
             className={styles['comment-submit']}
             value={comment || ''}
-            onChange={(__, data) => {
-              setComment(data.value);
-            }}
+            onChange={(__, {value}) => setComment(value)}
             action={!isSmallScreen}
           >
             <input />

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -167,7 +167,7 @@
 }
 
 :global(.ui.grid) .bottom-row:global(.row) {
-  margin-top: 4em;
+  margin-top: 4em !important; // Semantic sets ui.stackable.grid margins to zero
   justify-content: flex-end;
   align-items: baseline;
 
@@ -184,18 +184,11 @@
 
 @media screen and (max-width: 767px) {
   :global(.ui.grid) .bottom-row:global(.row) {
-    margin-top: 4em;
     flex-direction: column;
     align-items: center;
 
     .options-msg {
-      transition: color 0.25s ease-out;
-      color: $don-juan;
-      margin-right: 1em;
-
-      &:global(.none) {
-        color: $grey;
-      }
+      margin-bottom: 2em;
     }
   }
 }

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -188,7 +188,7 @@
     align-items: center;
 
     .options-msg {
-      margin-bottom: 2em;
+      margin-bottom: 1em;
     }
   }
 }
@@ -203,5 +203,22 @@
 
   .timezone-title {
     font-weight: bold;
+  }
+}
+
+.comment-submit {
+  width: 50%;
+}
+
+@media screen and (max-width: 767px) {
+  .comment-submit {
+    display: inline-block !important;
+    text-align: center;
+    width: unset;
+
+    input {
+      margin-bottom: 2em !important;
+      width: 100%;
+    }
   }
 }

--- a/newdle/migrations/versions/20200914_1149_679eab4aab01_add_comment_column_to_participants.py
+++ b/newdle/migrations/versions/20200914_1149_679eab4aab01_add_comment_column_to_participants.py
@@ -1,0 +1,27 @@
+"""Add comment column to participants
+
+Revision ID: 679eab4aab01
+Revises: 93a638b96375
+Create Date: 2020-09-14 11:49:41.751076
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '679eab4aab01'
+down_revision = '93a638b96375'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'participants',
+        sa.Column('comment', sa.String(), server_default='', nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_column('participants', 'comment')

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -90,7 +90,9 @@ class Participant(db.Model):
         unique=True,
     )
     _answers = db.Column('answers', JSONB, nullable=True, default={})
-    comment = db.Column('comment', db.String, nullable=False, default='')
+    comment = db.Column(
+        'comment', db.String, nullable=False, default='', server_default=''
+    )
     newdle_id = db.Column(
         db.Integer, db.ForeignKey('newdles.id'), nullable=False, index=True
     )

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -90,6 +90,7 @@ class Participant(db.Model):
         unique=True,
     )
     _answers = db.Column('answers', JSONB, nullable=True, default={})
+    comment = db.Column('comment', db.String, nullable=False, default='')
     newdle_id = db.Column(
         db.Integer, db.ForeignKey('newdles.id'), nullable=False, index=True
     )

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -79,7 +79,7 @@ class UpdateParticipantSchema(mm.Schema):
     answers = fields.Mapping(
         fields.DateTime(format=DATETIME_FORMAT), EnumField(Availability)
     )
-    comment = fields.String()
+    comment = fields.String(default='')
 
 
 class UpdateNewdleSchema(mm.Schema):

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -67,6 +67,7 @@ class ParticipantSchema(mm.Schema):
     answers = fields.Mapping(
         fields.DateTime(format=DATETIME_FORMAT), EnumField(Availability)
     )
+    comment = fields.String()
 
 
 class RestrictedParticipantSchema(ParticipantSchema):
@@ -78,6 +79,7 @@ class UpdateParticipantSchema(mm.Schema):
     answers = fields.Mapping(
         fields.DateTime(format=DATETIME_FORMAT), EnumField(Availability)
     )
+    comment = fields.String()
 
 
 class UpdateNewdleSchema(mm.Schema):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -79,6 +79,7 @@ def test_create_newdle(flask_client, dummy_uid, with_participants):
                 'auth_uid': 'guineapig',
                 'email': 'guineapig@example.com',
                 'name': 'Guinea Pig',
+                'comment': '',
             }
         ]
         if with_participants
@@ -224,14 +225,22 @@ def test_get_my_newdles(flask_client, dummy_uid, dummy_newdle):
                     'auth_uid': None,
                     'email': None,
                     'name': 'Albert Einstein',
+                    'comment': '',
                 },
                 {
                     'answers': {},
                     'auth_uid': 'pig',
                     'email': 'example@example.com',
                     'name': 'Guinea Pig',
+                    'comment': '',
                 },
-                {'answers': {}, 'auth_uid': None, 'email': None, 'name': 'Tony Stark'},
+                {
+                    'answers': {},
+                    'auth_uid': None,
+                    'email': None,
+                    'name': 'Tony Stark',
+                    'comment': '',
+                },
             ],
             'private': True,
             'timezone': 'Europe/Zurich',
@@ -312,14 +321,27 @@ def test_update_newdle(flask_client, dummy_newdle, dummy_uid):
             '2019-09-12T13:30',
         ],
         'participants': [
-            {'answers': {}, 'auth_uid': None, 'email': None, 'name': 'Albert Einstein'},
+            {
+                'answers': {},
+                'auth_uid': None,
+                'email': None,
+                'name': 'Albert Einstein',
+                'comment': '',
+            },
             {
                 'answers': {},
                 'auth_uid': 'pig',
                 'email': 'example@example.com',
                 'name': 'Guinea Pig',
+                'comment': '',
             },
-            {'answers': {}, 'auth_uid': None, 'email': None, 'name': 'Tony Stark'},
+            {
+                'answers': {},
+                'auth_uid': None,
+                'email': None,
+                'name': 'Tony Stark',
+                'comment': '',
+            },
         ],
         'timezone': 'Europe/Zurich',
         'title': 'Test event',
@@ -384,6 +406,7 @@ def test_newdles_participating(flask_client, dummy_newdle, dummy_participant_uid
             'code': 'part3',
             'email': 'example@example.com',
             'name': 'Guinea Pig',
+            'comment': '',
             'newdle': {
                 'code': 'dummy',
                 'creator_name': 'Dummy',
@@ -438,14 +461,27 @@ def test_get_participants(flask_client, dummy_newdle, dummy_uid):
         p.id for p in sorted(dummy_newdle.participants, key=attrgetter('name'))
     ]
     assert participants == [
-        {'answers': {}, 'auth_uid': None, 'email': None, 'name': 'Albert Einstein'},
+        {
+            'answers': {},
+            'auth_uid': None,
+            'email': None,
+            'name': 'Albert Einstein',
+            'comment': '',
+        },
         {
             'answers': {},
             'auth_uid': 'pig',
             'email': 'example@example.com',
             'name': 'Guinea Pig',
+            'comment': '',
         },
-        {'answers': {}, 'auth_uid': None, 'email': None, 'name': 'Tony Stark'},
+        {
+            'answers': {},
+            'auth_uid': None,
+            'email': None,
+            'name': 'Tony Stark',
+            'comment': '',
+        },
     ]
 
 
@@ -463,6 +499,7 @@ def test_get_participant_me(flask_client, dummy_newdle):
         'code': 'part3',
         'email': 'example@example.com',
         'name': 'Guinea Pig',
+        'comment': '',
     }
 
 
@@ -493,6 +530,7 @@ def test_get_participant(flask_client, dummy_newdle):
         'auth_uid': None,
         'email': None,
         'name': 'Tony Stark',
+        'comment': '',
         'code': 'part1',
     }
 
@@ -510,6 +548,7 @@ def test_update_participant_empty(flask_client, dummy_newdle):
         'auth_uid': None,
         'email': None,
         'name': 'Tony Stark',
+        'comment': '',
         'code': 'part1',
     }
 
@@ -571,6 +610,7 @@ def test_update_participant_answers_valid_slots(flask_client, dummy_newdle):
         'auth_uid': None,
         'email': None,
         'name': 'Tony Stark',
+        'comment': '',
         'code': 'part1',
     }
 
@@ -608,7 +648,13 @@ def test_create_unknown_participant(flask_client):
     code = data.pop('code')
     id_ = data.pop('id')
     participant = Participant.query.filter_by(name=name).first()
-    assert data == {'answers': {}, 'auth_uid': None, 'email': None, 'name': name}
+    assert data == {
+        'answers': {},
+        'auth_uid': None,
+        'email': None,
+        'name': name,
+        'comment': '',
+    }
     assert Participant.query.count() == num_participants + 1
     assert participant.code == code
     assert participant.id == id_
@@ -670,5 +716,6 @@ def test_create_participant(flask_client, dummy_newdle, dummy_uid):
         'auth_uid': 'user123',
         'email': 'example@example.com',
         'name': 'Guinea Pig',
+        'comment': '',
     }
     assert Participant.query.count() == nb_participant + 1


### PR DESCRIPTION
Closes #142 

A proposal for participant comments. 
These can easily be set, unset or replaced in the answers page.

![image](https://user-images.githubusercontent.com/12183954/93088089-c55f2e80-f699-11ea-9c6e-9a163c15338f.png)
