### PR TITLE
Fix bottommost slots position in answer page (#221)

### DIFF
--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -153,6 +153,11 @@ function calculateBusyPositions(busyTimes, minHour, maxHour) {
   });
 }
 
+function calculateHourPositions(minHour, maxHour, hourStep) {
+  const hourSpan = maxHour - minHour;
+  return _.range(0, hourSpan + hourStep, hourStep).map(i => (i / hourSpan) * 100);
+}
+
 function Hours({minHour, maxHour, hourStep}) {
   const hourSeries = hourRange(minHour, maxHour, hourStep);
   const hourSpan = maxHour - minHour;
@@ -243,6 +248,11 @@ export default function Calendar() {
                 options={item}
                 busySlots={busyByDay.find(busySlot => busySlot.date === item.date)}
                 selected={isActiveDay(item.date)}
+                hourPositions={calculateHourPositions(
+                  minHour,
+                  maxHour,
+                  Hours.defaultProps.hourStep
+                )}
               />
             </Grid.Column>
           )}

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -35,12 +35,12 @@ export default function DayTimeline({options, busySlots, selected, hourPositions
         {options.optionGroups.map(group => {
           const size = group.length;
           if (size < 4) {
-            const width = 90 / size;
+            const width = 100 / size;
             return group.map((option, index) => (
               <Slot
                 {...option}
                 width={width}
-                left={width * index + 5}
+                left={width * index}
                 key={option.slot}
                 className={`${styles['answer-slot']} ${styles[option.answer]}`}
                 content={<Option {...option} />}

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -10,7 +10,7 @@ import Option from './Option';
 import {useDispatch} from 'react-redux';
 import styles from './answer.module.scss';
 
-export default function DayTimeline({options, busySlots, selected}) {
+export default function DayTimeline({options, busySlots, selected, hourPositions}) {
   const numDaysVisible = useNumDaysVisible();
   const dispatch = useDispatch();
   // This date does not need to be timezone casted as we are only format correcting
@@ -24,15 +24,23 @@ export default function DayTimeline({options, busySlots, selected}) {
         {formattedDate}
       </Header>
       <div className={styles['options-column']}>
+        {hourPositions &&
+          hourPositions.map(i => (
+            <hr
+              key={`hour-sep-${i}`}
+              className={styles['hours-separator']}
+              style={{top: `${i}%`}}
+            />
+          ))}
         {options.optionGroups.map(group => {
           const size = group.length;
           if (size < 4) {
-            const width = 100 / size;
+            const width = 90 / size;
             return group.map((option, index) => (
               <Slot
                 {...option}
                 width={width}
-                left={width * index}
+                left={width * index + 5}
                 key={option.slot}
                 className={`${styles['answer-slot']} ${styles[option.answer]}`}
                 content={<Option {...option} />}
@@ -65,6 +73,7 @@ DayTimeline.propTypes = {
   options: PropTypes.object.isRequired,
   busySlots: PropTypes.object,
   selected: PropTypes.bool.isRequired,
+  hourPositions: PropTypes.array,
 };
 
 DayTimeline.defaultProps = {

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -25,12 +25,8 @@ export default function DayTimeline({options, busySlots, selected, hourPositions
       </Header>
       <div className={styles['options-column']}>
         {hourPositions &&
-          hourPositions.map(i => (
-            <hr
-              key={`hour-sep-${i}`}
-              className={styles['hours-separator']}
-              style={{top: `${i}%`}}
-            />
+          hourPositions.map(pos => (
+            <hr key={pos} className={styles['hours-separator']} style={{top: `${pos}%`}} />
           ))}
         {options.optionGroups.map(group => {
           const size = group.length;

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -22,7 +22,7 @@
   position: relative;
   width: 100%;
   height: 750px;
-  margin-top: 25px;
+  margin-top: 35px;
 
   .hour {
     position: absolute;

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -27,6 +27,9 @@
   .hour {
     position: absolute;
     color: $grey;
+    width: 25px;
+    background-color: white;
+    z-index: 1;
   }
 }
 
@@ -171,11 +174,12 @@
 
   .hours-separator {
     position: absolute;
-    border: 0px;
-    width: 100%;
+    border: 0;
+    width: 114%;
     height: 1px;
-    margin: 0px;
+    margin: 0;
     background-color: #e6e6e6;
+    left: -7%;
   }
 }
 

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -22,7 +22,7 @@
   position: relative;
   width: 100%;
   height: 750px;
-  margin-top: 35px;
+  margin-top: 25px;
 
   .hour {
     position: absolute;
@@ -70,7 +70,7 @@
 
     &.unavailable {
       color: $don-juan;
-      background-color: rgba($grey, 0.3);
+      background-color: #d9d9d9;
       border: 1px solid rgba($grey, 0.5);
 
       &:global(.overlapping):hover {
@@ -81,7 +81,7 @@
 
     &.available {
       color: $dark-green;
-      background-color: rgba($green, 0.5);
+      background-color: #b0f9b6;
       border: 1px solid rgba($dark-green, 0.3);
 
       &:global(.overlapping):hover {
@@ -91,7 +91,7 @@
 
     &.ifneedbe {
       color: $dark-yellow;
-      background-color: rgba($yellow, 0.5);
+      background-color: #fcf4b5;
       border: 1px solid rgba($dark-yellow, 0.3);
 
       &:global(.overlapping):hover {
@@ -141,18 +141,18 @@
       user-select: none;
 
       &.unavailable {
-        background-color: rgba($grey, 0.3);
+        background-color: #d9d9d9;
         color: $don-juan;
       }
 
       &.available {
         color: $dark-green;
-        background-color: rgba($green, 0.5);
+        background-color: #b0f9b6;
       }
 
       &.ifneedbe {
         color: $dark-yellow;
-        background-color: rgba($yellow, 0.5);
+        background-color: #fcf4b5;
       }
 
       i:global(.icon) {
@@ -167,6 +167,15 @@
     border: 1px solid darken($peach, 20%);
     opacity: 0.3;
     width: 100%;
+  }
+
+  .hours-separator {
+    position: absolute;
+    border: 0px;
+    width: 100%;
+    height: 1px;
+    margin: 0px;
+    background-color: #e6e6e6;
   }
 }
 

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -52,7 +52,7 @@
 .options-column {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 750px;
   margin: 1px;
 
   .answer-slot {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8865522/93187050-a1eebf00-f73f-11ea-952c-382a6460e5b3.png)

This change makes the hours and answers columns with the same height, fixing the bottommost answers position. I used a header with a white space for having the same fixed-height elements in the hours and answers columns, but I'm not sure if it's the prettiest solution.

closes #221 