### PR TITLE
Fix squeezed user avatars in timeline

### DIFF
--- a/newdle/client/src/components/ParticipantTable.module.scss
+++ b/newdle/client/src/components/ParticipantTable.module.scss
@@ -56,7 +56,8 @@
           flex: 5;
 
           .user-element {
-            display: block;
+            display: flex;
+            align-items: center;
             padding: 5px 0;
             margin-right: 5px;
           }

--- a/newdle/client/src/components/creation/timeslots/Timeline.module.scss
+++ b/newdle/client/src/components/creation/timeslots/Timeline.module.scss
@@ -50,12 +50,19 @@ $label-width: 180px;
         .avatar {
           color: $grey;
           display: flex;
+          width: 100%;
           align-items: center;
           padding-right: 20px;
 
+          span {
+            flex: 2;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+
           img {
-            margin-left: 10px;
             border-radius: 50%;
+            flex: 0.5;
           }
         }
       }


### PR DESCRIPTION
closes #108

Now:

<img width="460" alt="Screenshot 2020-09-15 at 16 32 57" src="https://user-images.githubusercontent.com/3616940/93224205-29085b00-f771-11ea-929b-cba7261f3ebf.png">

Also noticed a few misalignments in the `ParticipantTable`.

Before:

<img width="416" alt="Screenshot 2020-09-15 at 16 26 27" src="https://user-images.githubusercontent.com/3616940/93224277-39203a80-f771-11ea-921c-b569585e8063.png">

After:

<img width="416" alt="Screenshot 2020-09-15 at 16 26 45" src="https://user-images.githubusercontent.com/3616940/93224304-3f161b80-f771-11ea-8ce6-f2c26888d0d6.png">
