### PR TITLE
Add 'get_busy_times' API test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ dev =
     ipython
     isort>=5.0.3
     pytest
+    pytest-mock
     pytest-cov
     wheel
 exchange = exchangelib

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6,6 +6,7 @@ import pytest
 from flask import url_for
 from werkzeug.exceptions import Forbidden
 
+from newdle import api
 from newdle.core.auth import app_token_from_multipass
 from newdle.models import Newdle, Participant
 
@@ -157,6 +158,26 @@ def test_create_newdle_participant_email_sending(flask_client, dummy_uid, mail_q
     )
     assert len(mail_queue) == 1
     assert resp.status_code == 200
+
+
+def test_get_busy_times(flask_client, dummy_uid):
+    _get_busy_times = api._get_busy_times
+    api._get_busy_times = Mock(return_value={})
+
+    resp = flask_client.get(
+        url_for('api.get_busy_times'),
+        **make_test_auth(dummy_uid),
+        json={'date': '2020-09-16', 'tz': 'US/Pacific', 'uid': '17'},
+    )
+    assert resp.status_code == 200
+
+    resp = flask_client.get(
+        url_for('api.get_busy_times'),
+        json={'date': '2020-09-16', 'tz': 'US/Pacific', 'uid': '17'},
+    )
+    assert resp.status_code == 401
+
+    api._get_busy_times = _get_busy_times
 
 
 @pytest.mark.usefixtures('db_session')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6,7 +6,6 @@ import pytest
 from flask import url_for
 from werkzeug.exceptions import Forbidden
 
-from newdle import api
 from newdle.core.auth import app_token_from_multipass
 from newdle.models import Newdle, Participant
 
@@ -160,9 +159,13 @@ def test_create_newdle_participant_email_sending(flask_client, dummy_uid, mail_q
     assert resp.status_code == 200
 
 
-def test_get_busy_times(flask_client, dummy_uid):
-    _get_busy_times = api._get_busy_times
-    api._get_busy_times = Mock(return_value={})
+def test_get_busy_times(flask_client, dummy_uid, monkeypatch):
+    def mock_get_busy(date, tz, uid):
+        return {}
+
+    from newdle import api
+
+    monkeypatch.setattr(api, '_get_busy_times', mock_get_busy)
 
     resp = flask_client.get(
         url_for('api.get_busy_times'),
@@ -176,8 +179,6 @@ def test_get_busy_times(flask_client, dummy_uid):
         json={'date': '2020-09-16', 'tz': 'US/Pacific', 'uid': '17'},
     )
     assert resp.status_code == 401
-
-    api._get_busy_times = _get_busy_times
 
 
 @pytest.mark.usefixtures('db_session')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from operator import attrgetter, itemgetter
 from unittest.mock import Mock
 
@@ -6,6 +6,7 @@ import pytest
 from flask import url_for
 from werkzeug.exceptions import Forbidden
 
+from newdle import api
 from newdle.core.auth import app_token_from_multipass
 from newdle.models import Newdle, Participant
 
@@ -159,26 +160,22 @@ def test_create_newdle_participant_email_sending(flask_client, dummy_uid, mail_q
     assert resp.status_code == 200
 
 
-def test_get_busy_times(flask_client, dummy_uid, monkeypatch):
-    def mock_get_busy(date, tz, uid):
-        return {}
-
-    from newdle import api
-
-    monkeypatch.setattr(api, '_get_busy_times', mock_get_busy)
+def test_get_busy_times(flask_client, dummy_uid, mocker):
+    mocker.patch('newdle.api._get_busy_times', return_value={})
+    json = {'date': '2020-09-16', 'tz': 'US/Pacific', 'uid': '17'}
 
     resp = flask_client.get(
-        url_for('api.get_busy_times'),
-        **make_test_auth(dummy_uid),
-        json={'date': '2020-09-16', 'tz': 'US/Pacific', 'uid': '17'},
+        url_for('api.get_busy_times'), **make_test_auth(dummy_uid), json=json
     )
     assert resp.status_code == 200
-
-    resp = flask_client.get(
-        url_for('api.get_busy_times'),
-        json={'date': '2020-09-16', 'tz': 'US/Pacific', 'uid': '17'},
+    api._get_busy_times.assert_called_once_with(
+        date.fromisoformat(json['date']), json['tz'], json['uid']
     )
+    api._get_busy_times.reset_mock()
+
+    resp = flask_client.get(url_for('api.get_busy_times'), json=json)
     assert resp.status_code == 401
+    api._get_busy_times.assert_not_called()
 
 
 @pytest.mark.usefixtures('db_session')


### PR DESCRIPTION
Ensures that the given endpoint requires authentication.
The API should respond with `200` for valid auth and `401` when no auth is provided