### PR TITLE
Fix timezone dropdown for newdle creation

### DIFF
--- a/newdle/client/src/components/creation/timeslots/DurationPicker.module.scss
+++ b/newdle/client/src/components/creation/timeslots/DurationPicker.module.scss
@@ -1,9 +1,9 @@
 .duration-picker {
-  height: 38px !important;
+  height: 41px !important;
   width: 14em;
 
   :global(.rc-time-picker-input) {
-    height: 38px;
+    height: 41px;
     font-size: 14px;
     font-family: inherit;
     color: black;
@@ -16,7 +16,7 @@
     font-size: 14px;
     font-family: inherit;
     padding-left: 7.5px;
-    margin-top: 3px;
+    margin-top: 4.5px;
   }
 
   :global(.rc-time-picker-panel-select) {

--- a/newdle/client/src/components/creation/timeslots/Timeline.module.scss
+++ b/newdle/client/src/components/creation/timeslots/Timeline.module.scss
@@ -244,7 +244,7 @@ $label-width: 180px;
 
   > * {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
 
     :global(.ui.dropdown) {
@@ -253,6 +253,19 @@ $label-width: 180px;
 
     &:not(:last-child) {
       padding-bottom: 0.5em;
+    }
+  }
+
+  :global(.ui.dropdown) {
+    width: 14em;
+
+    :global(.divider.text) {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      width: 100%;
+      // keep letters like g and p from being cut off at the bottom
+      line-height: calc(1em + 1.5px);
     }
   }
 }


### PR DESCRIPTION
The timezone label will now keep the same width and the text inside will be ellipsised accordingly. The 'Timezone' label does not jump to the bottom of the box anymore when typing in the box and no result is found.
![Bildschirmfoto 2020-09-22 um 11 33 15](https://user-images.githubusercontent.com/23189858/93869562-3cb14580-fccc-11ea-8a00-b0d4140708e4.png)
