### PR TITLE
Add snapshot tests for plaintext emails

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ dev =
     pytest
     pytest-mock
     pytest-cov
+    pytest-snapshot
     wheel
 exchange = exchangelib
 cern = Flask-Multipass-CERN>=1.0.dev4

--- a/tests/emails/new-available-comment.txt
+++ b/tests/emails/new-available-comment.txt
@@ -1,0 +1,13 @@
+Hi,
+
+Arthas Menethil replied to "Unleashing the scourge".
+
+Available dates:
+- 23/09/2020, 10:00
+- 23/09/2020, 12:00 (if needed)
+- 24/09/2020, 11:00
+
+Comment: You are not prepared
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/new-available-nocomment.txt
+++ b/tests/emails/new-available-nocomment.txt
@@ -1,0 +1,11 @@
+Hi,
+
+Arthas Menethil replied to "Unleashing the scourge".
+
+Available dates:
+- 23/09/2020, 10:00
+- 23/09/2020, 12:00 (if needed)
+- 24/09/2020, 11:00
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/new-unavailable-comment.txt
+++ b/tests/emails/new-unavailable-comment.txt
@@ -1,0 +1,10 @@
+Hi,
+
+Arthas Menethil replied to "Unleashing the scourge".
+
+Not available at any of the dates.
+
+Comment: You are not prepared
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/new-unavailable-nocomment.txt
+++ b/tests/emails/new-unavailable-nocomment.txt
@@ -1,0 +1,8 @@
+Hi,
+
+Arthas Menethil replied to "Unleashing the scourge".
+
+Not available at any of the dates.
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/update-available-comment.txt
+++ b/tests/emails/update-available-comment.txt
@@ -1,0 +1,13 @@
+Hi,
+
+Arthas Menethil updated their answer for "Unleashing the scourge".
+
+Available dates:
+- 23/09/2020, 10:00
+- 23/09/2020, 12:00 (if needed)
+- 24/09/2020, 11:00
+
+Comment: You are not prepared
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/update-available-nocomment.txt
+++ b/tests/emails/update-available-nocomment.txt
@@ -1,0 +1,11 @@
+Hi,
+
+Arthas Menethil updated their answer for "Unleashing the scourge".
+
+Available dates:
+- 23/09/2020, 10:00
+- 23/09/2020, 12:00 (if needed)
+- 24/09/2020, 11:00
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/update-unavailable-comment.txt
+++ b/tests/emails/update-unavailable-comment.txt
@@ -1,0 +1,10 @@
+Hi,
+
+Arthas Menethil updated their answer for "Unleashing the scourge".
+
+Not available at any of the dates.
+
+Comment: You are not prepared
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/emails/update-unavailable-nocomment.txt
+++ b/tests/emails/update-unavailable-nocomment.txt
@@ -1,0 +1,8 @@
+Hi,
+
+Arthas Menethil updated their answer for "Unleashing the scourge".
+
+Not available at any of the dates.
+
+Check all results on the summary page:
+http://flask.test/newdle/foo/summary

--- a/tests/notifications_test.py
+++ b/tests/notifications_test.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from flask import render_template, url_for
+
+
+@pytest.mark.parametrize(
+    ('update', 'available', 'comment', 'snapshot_name'),
+    (
+        (False, False, False, 'new-unavailable-nocomment.txt'),
+        (False, False, True, 'new-unavailable-comment.txt'),
+        (False, True, False, 'new-available-nocomment.txt'),
+        (False, True, True, 'new-available-comment.txt'),
+        (True, False, False, 'update-unavailable-nocomment.txt'),
+        (True, False, True, 'update-unavailable-comment.txt'),
+        (True, True, False, 'update-available-nocomment.txt'),
+        (True, True, True, 'update-available-comment.txt'),
+    ),
+)
+def test_replied_email_plaintext(snapshot, update, available, comment, snapshot_name):
+    answers = []
+    if available:
+        answers = [
+            (datetime(2020, 9, 23, 10), False),
+            (datetime(2020, 9, 23, 12), True),
+            (datetime(2020, 9, 24, 11), False),
+        ]
+
+    text = render_template(
+        'replied_email.txt',
+        update=update,
+        participant='Arthas Menethil',
+        title='Unleashing the scourge',
+        comment='You are not prepared' if comment else '',
+        answers=answers,
+        summary_link=url_for('newdle_summary', code='foo', _external=True),
+    )
+
+    snapshot.snapshot_dir = Path(__file__).parent / 'emails'
+    snapshot.assert_match(text, snapshot_name)


### PR DESCRIPTION
It's very easy to get line breaks wrong in there, because generating plaintext emails is *nasty* as soon as there are any jinja constructs involved.