### PR TITLE
Change logic for arrows in answer view

### DIFF
--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -205,8 +205,8 @@ export function setAnswer(timeslot, answer) {
   };
 }
 
-export function setAnswerActiveDate(date) {
-  return {type: SET_ANSWER_ACTIVE_DATE, date};
+export function setAnswerActiveDate(date, position) {
+  return {type: SET_ANSWER_ACTIVE_DATE, date, position};
 }
 
 export function updateNewdle(newdle) {

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -47,7 +47,23 @@ export const getCalendarDates = createSelector(
 );
 
 export const getActiveDate = state =>
-  state.answer.calendarActiveDate || getCalendarDates(state)[0] || serializeDate(moment());
+  state.answer.calendarActiveDate
+    ? state.answer.calendarActiveDate.date
+    : getCalendarDates(state)[0] || serializeDate(moment());
+
+export const getActivePosition = state =>
+  state.answer.calendarActiveDate ? state.answer.calendarActiveDate.pos : 0;
+
+export const getDateIndexes = createSelector(
+  getCalendarDates,
+  dates => _.fromPairs(dates.map((d, i) => [d, i]))
+);
+
+export const getActiveDateIndex = createSelector(
+  getDateIndexes,
+  getActiveDate,
+  (dateIndexes, activeDate) => dateIndexes[activeDate]
+);
 
 /** Whether busy times are known */
 const hasBusyTimes = state => state.answer.busyTimes !== null;

--- a/newdle/client/src/components/DayCarousel.js
+++ b/newdle/client/src/components/DayCarousel.js
@@ -4,18 +4,29 @@ import {Icon} from 'semantic-ui-react';
 
 import styles from './DayCarousel.module.scss';
 
-export default function DayCarousel({items, numberOfVisible, start, step, renderItem, changeItem}) {
+export default function DayCarousel({
+  items,
+  numberOfVisible,
+  activeIndex,
+  activePosition,
+  step,
+  renderItem,
+  changeItem,
+}) {
   const next = () => {
-    const newIndex = (start + step) % items.length;
+    const newIndex = (activeIndex + step) % items.length;
+    const nextPosition =
+      activePosition + step < numberOfVisible ? activePosition + step : numberOfVisible - 1;
     if (changeItem) {
-      changeItem(items[newIndex]);
+      changeItem(items[newIndex], nextPosition);
     }
   };
 
   const prev = () => {
-    const newIndex = Math.max(start - step, 0);
+    const newIndex = Math.max(activeIndex - step, 0);
+    const nextPosition = activePosition - step >= 0 ? activePosition - step : 0;
     if (changeItem) {
-      changeItem(items[newIndex]);
+      changeItem(items[newIndex], nextPosition);
     }
   };
 
@@ -26,10 +37,10 @@ export default function DayCarousel({items, numberOfVisible, start, step, render
     fromIndex = 0;
     toIndex = items.length;
   } else {
-    showPrevBtn = start !== 0;
-    showNextBtn = start + numberOfVisible < items.length;
-    fromIndex = Math.min(items.length - numberOfVisible, start);
-    toIndex = start + numberOfVisible;
+    showPrevBtn = activeIndex !== 0;
+    showNextBtn = activeIndex < items.length - 1;
+    fromIndex = activeIndex - activePosition < 0 ? 0 : activeIndex - activePosition;
+    toIndex = activeIndex + (numberOfVisible - activePosition);
   }
 
   return (
@@ -48,7 +59,8 @@ export default function DayCarousel({items, numberOfVisible, start, step, render
 DayCarousel.propTypes = {
   items: PropTypes.array.isRequired,
   numberOfVisible: PropTypes.number,
-  start: PropTypes.number,
+  activeIndex: PropTypes.number,
+  activePosition: PropTypes.number,
   step: PropTypes.number,
   renderItem: PropTypes.func.isRequired,
   changeItem: PropTypes.func,
@@ -56,7 +68,8 @@ DayCarousel.propTypes = {
 
 DayCarousel.defaultProps = {
   numberOfVisible: 3,
-  start: 0,
+  activeIndex: 0,
+  activePosition: 0,
   step: 1,
   changeItem: null,
 };

--- a/newdle/client/src/components/answer/Calendar.js
+++ b/newdle/client/src/components/answer/Calendar.js
@@ -5,10 +5,12 @@ import PropTypes from 'prop-types';
 import {Grid} from 'semantic-ui-react';
 import {useDispatch, useSelector} from 'react-redux';
 import {hourRange, serializeDate, toMoment, getHourSpan} from '../../util/date';
-import {useIsSmallScreen} from '../../util/hooks';
+import {useIsSmallScreen, useNumDaysVisible} from '../../util/hooks';
 import DayTimeline from './DayTimeline';
 import {
   getActiveDate,
+  getActivePosition,
+  getActiveDateIndex,
   getLocalNewdleTimeslots,
   getNewdleDuration,
   getAnswers,
@@ -191,8 +193,11 @@ export default function Calendar() {
   const newdleTz = useSelector(getNewdleTimezone);
   const userTz = useSelector(getUserTimezone);
   const activeDate = toMoment(useSelector(getActiveDate), HTML5_FMT.DATE);
+  const activeDatePosition = useSelector(getActivePosition);
+  const activeDateIndex = useSelector(getActiveDateIndex);
   const dispatch = useDispatch();
 
+  const numDaysVisible = useNumDaysVisible();
   const defaultHourSpan = MAX_HOUR - MIN_HOUR;
   const isTabletOrMobile = useIsSmallScreen();
 
@@ -220,12 +225,9 @@ export default function Calendar() {
     userTz
   );
   const busyByDay = calculateBusyPositions(busyTimes, minHour, maxHour);
-  const activeDateIndex = optionsByDay.findIndex(({date: timeSlotDate}) =>
-    toMoment(timeSlotDate, HTML5_FMT.DATE).isSame(activeDate, 'day')
-  );
-  const numDaysVisible = isTabletOrMobile ? 1 : 3;
   const numColumns = isTabletOrMobile ? 14 : 5;
   const isActiveDay = date => activeDate.isSame(date);
+
   return (
     <Grid>
       <Grid.Row>
@@ -234,9 +236,12 @@ export default function Calendar() {
         </Grid.Column>
         <DayCarousel
           numberOfVisible={numDaysVisible}
-          start={activeDateIndex === -1 ? 0 : activeDateIndex}
+          activeIndex={activeDateIndex === -1 ? 0 : activeDateIndex}
           items={optionsByDay}
-          changeItem={nextItem => dispatch(setAnswerActiveDate(nextItem.date))}
+          changeItem={(nextItem, position) => {
+            dispatch(setAnswerActiveDate(nextItem.date, position));
+          }}
+          activePosition={activeDatePosition}
           renderItem={item => (
             <Grid.Column width={numColumns} key={item.date}>
               <DayTimeline

--- a/newdle/client/src/reducers/answer.js
+++ b/newdle/client/src/reducers/answer.js
@@ -72,7 +72,7 @@ export default combineReducers({
   calendarActiveDate: (state = null, action) => {
     switch (action.type) {
       case SET_ANSWER_ACTIVE_DATE:
-        return action.date;
+        return {date: action.date, pos: action.position};
       case ABORT_ANSWERING:
         return null;
       default:


### PR DESCRIPTION
Pressing the arrows will now change the active date without switching the whole view unless necessary.
Closes #254.