### PR TITLE
Add i18n capabilities to NewdleTitle component

### DIFF
--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -4,6 +4,7 @@ import {useSelector} from 'react-redux';
 import {useHistory} from 'react-router';
 import {useRouteMatch} from 'react-router-dom';
 import {Container, Icon, Button, Popup} from 'semantic-ui-react';
+import {Trans, t} from '@lingui/macro';
 import {getUserInfo} from '../selectors';
 import {getStoredParticipantCodeForNewdle} from '../answerSelectors';
 import styles from './NewdleTitle.module.scss';
@@ -30,15 +31,19 @@ export default function NewdleTitle({
       <div className={styles['flexbox']}>
         <div>
           <div className={styles['title']}>
-            <h1 className={styles['header']}>{title}</h1>
+            <h1 className={styles['header']}>
+              <Trans>{title}</Trans>
+            </h1>
           </div>
-          <div className={styles['subtitle']}>by {author}</div>
+          <div className={styles['subtitle']}>
+            <Trans>by {author}</Trans>
+          </div>
         </div>
         {!isDeleted && (!isPrivate || (userInfo && userInfo.uid === creatorUid)) && (
           <div className={styles['view-options']}>
             <Button.Group>
               <Popup
-                content={!finished ? 'Answer newdle' : 'This newdle has already finished'}
+                content={!finished ? t`Answer newdle` : t`This newdle has already finished`}
                 position="bottom center"
                 trigger={
                   <Button

--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -31,9 +31,7 @@ export default function NewdleTitle({
       <div className={styles['flexbox']}>
         <div>
           <div className={styles['title']}>
-            <h1 className={styles['header']}>
-              <Trans>{title}</Trans>
-            </h1>
+            <h1 className={styles['header']}>{title}</h1>
           </div>
           <div className={styles['subtitle']}>
             <Trans>by {author}</Trans>

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -25,6 +25,10 @@ msgstr "<0>newdle</0> guardará las respuestas"
 msgid "Accept all options where I'm available"
 msgstr ""
 
+#: src/components/NewdleTitle.js:46
+msgid "Answer newdle"
+msgstr ""
+
 #: src/components/answer/AnswerPage.js:73
 msgid "Answering on behalf of:"
 msgstr ""
@@ -136,6 +140,7 @@ msgstr ""
 msgid "The participants have been notified of the final date."
 msgstr ""
 
+#: src/components/NewdleTitle.js:46
 #: src/components/answer/AnswerPage.js:191
 msgid "This newdle has already finished"
 msgstr ""
@@ -165,6 +170,10 @@ msgstr "Puedes usarlo para conocer los mejores dias/fechas para tus reuniones."
 msgid "Your answer has been saved!"
 msgstr ""
 
+#: src/components/NewdleTitle.js:39
+msgid "by {author}"
+msgstr ""
+
 #: src/components/home/HomePage.js:63
 msgid "newdle is Open Source Software"
 msgstr "newdle es Software de código abierto"
@@ -191,4 +200,8 @@ msgstr ""
 
 #: src/components/answer/AnswerPage.js:293
 msgid "{numberOfTimeslots, plural, one {{numberOfAvailable} out of # option chosen} other {{numberOfAvailable} out of # options chosen}}"
+msgstr ""
+
+#: src/components/NewdleTitle.js:35
+msgid "{title}"
 msgstr ""

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -25,7 +25,7 @@ msgstr "<0>newdle</0> guardará las respuestas"
 msgid "Accept all options where I'm available"
 msgstr ""
 
-#: src/components/NewdleTitle.js:46
+#: src/components/NewdleTitle.js:44
 msgid "Answer newdle"
 msgstr ""
 
@@ -140,7 +140,7 @@ msgstr ""
 msgid "The participants have been notified of the final date."
 msgstr ""
 
-#: src/components/NewdleTitle.js:46
+#: src/components/NewdleTitle.js:44
 #: src/components/answer/AnswerPage.js:191
 msgid "This newdle has already finished"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr "Puedes usarlo para conocer los mejores dias/fechas para tus reuniones."
 msgid "Your answer has been saved!"
 msgstr ""
 
-#: src/components/NewdleTitle.js:39
+#: src/components/NewdleTitle.js:37
 msgid "by {author}"
 msgstr ""
 
@@ -200,8 +200,4 @@ msgstr ""
 
 #: src/components/answer/AnswerPage.js:293
 msgid "{numberOfTimeslots, plural, one {{numberOfAvailable} out of # option chosen} other {{numberOfAvailable} out of # options chosen}}"
-msgstr ""
-
-#: src/components/NewdleTitle.js:35
-msgid "{title}"
 msgstr ""


### PR DESCRIPTION
Added <Trans> tag and `t` to template literal text.

closes #280 