### PR TITLE
Fixes #285-Add i18n: TimeslotsStep

### DIFF
--- a/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
+++ b/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
+import {Trans} from '@lingui/macro';
 import _ from 'lodash';
 import {Button, Grid, Icon, Segment} from 'semantic-ui-react';
-import {Trans} from '@lingui/macro';
 import {setStep} from '../../../actions';
 import {getFullTimeslots} from '../../../selectors';
 import Availability from './Availability';

--- a/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
+++ b/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {Trans} from '@lingui/macro';
+import {Trans, Plural} from '@lingui/macro';
 import _ from 'lodash';
 import {Button, Grid, Icon, Segment} from 'semantic-ui-react';
 import {setStep} from '../../../actions';
@@ -19,19 +19,19 @@ function SelectedDates() {
       attached="bottom"
     >
       {numSlots ? (
-        numSlots === 1 ? (
-          <span>
+        <Plural
+          value={numSlots}
+          one={
             <Trans>
-              <strong>1</strong> slot added
+              <strong>#</strong> slot added
             </Trans>
-          </span>
-        ) : (
-          <span>
+          }
+          other={
             <Trans>
-              <strong>{numSlots}</strong> slots added
+              <strong>#</strong> slots added
             </Trans>
-          </span>
-        )
+          }
+        />
       ) : (
         <em>
           <Trans>You haven't added any slots yet</Trans>

--- a/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
+++ b/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import _ from 'lodash';
 import {Button, Grid, Icon, Segment} from 'semantic-ui-react';
+import {Trans} from '@lingui/macro';
 import {setStep} from '../../../actions';
 import {getFullTimeslots} from '../../../selectors';
 import Availability from './Availability';
@@ -20,15 +21,21 @@ function SelectedDates() {
       {numSlots ? (
         numSlots === 1 ? (
           <span>
-            <strong>1</strong> slot added
+            <Trans>
+              <strong>1</strong> slot added
+            </Trans>
           </span>
         ) : (
           <span>
-            <strong>{numSlots}</strong> slots added
+            <Trans>
+              <strong>{numSlots}</strong> slots added
+            </Trans>
           </span>
         )
       ) : (
-        <em>You haven't added any slots yet</em>
+        <em>
+          <Trans>You haven't added any slots yet</Trans>
+        </em>
       )}
     </Segment>
   );
@@ -56,7 +63,7 @@ export default function TimeslotsStep() {
         <Grid.Row>
           <div className={styles['button-row']}>
             <Button color="violet" icon labelPosition="left" onClick={() => dispatch(setStep(1))}>
-              Back
+              <Trans>Back</Trans>
               <Icon name="angle left" />
             </Button>
             <Button
@@ -66,7 +73,7 @@ export default function TimeslotsStep() {
               disabled={!timeslots.length}
               onClick={() => dispatch(setStep(3))}
             >
-              Next step
+              <Trans>Next step</Trans>
               <Icon name="angle right" />
             </Button>
           </div>

--- a/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
+++ b/newdle/client/src/components/creation/timeslots/TimeslotsStep.js
@@ -18,25 +18,20 @@ function SelectedDates() {
       className={`${styles['selected-dates']} ${numSlots ? styles.active : ''}`}
       attached="bottom"
     >
-      {numSlots ? (
-        <Plural
-          value={numSlots}
-          one={
-            <Trans>
-              <strong>#</strong> slot added
-            </Trans>
-          }
-          other={
-            <Trans>
-              <strong>#</strong> slots added
-            </Trans>
-          }
-        />
-      ) : (
-        <em>
-          <Trans>You haven't added any slots yet</Trans>
-        </em>
-      )}
+      <Plural
+        value={numSlots}
+        one={
+          <Trans>
+            <strong>#</strong> slot added
+          </Trans>
+        }
+        other={
+          <Trans>
+            <strong>#</strong> slots added
+          </Trans>
+        }
+        _0="You haven't added any slots yet"
+      />
     </Segment>
   );
 }

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/creation/timeslots/TimeslotsStep.js:24
+msgid "<0>1</0> slot added"
+msgstr ""
+
 #: src/components/home/HomeHeader.js:11
 msgid "<0>newdle</0> is a collective meeting scheduling application."
 msgstr "<0>newdle</0> es una aplicación para programar reuniones colectivamente."
@@ -22,6 +26,11 @@ msgid "<0>newdle</0> will collect the answers!"
 msgstr "<0>newdle</0> guardará las respuestas"
 
 #: src/components/answer/AnswerPage.js:232
+#: src/components/creation/timeslots/TimeslotsStep.js:30
+msgid "<0>{numSlots}</0> slots added"
+msgstr ""
+
+#: src/components/answer/AnswerPage.js:233
 msgid "Accept all options where I'm available"
 msgstr ""
 
@@ -60,6 +69,11 @@ msgstr ""
 #: src/components/creation/userSearch/UserSearch.js:136
 #: src/components/login/LoginPrompt.js:45
 #: src/components/summary/SummaryPage.js:165
+#: src/components/creation/timeslots/TimeslotsStep.js:66
+msgid "Back"
+msgstr ""
+
+#: src/components/summary/SummaryPage.js:166
 msgid "Cancel"
 msgstr ""
 
@@ -232,6 +246,11 @@ msgid "No data"
 msgstr ""
 
 #: src/components/answer/AnswerPage.js:300
+#: src/components/creation/timeslots/TimeslotsStep.js:76
+msgid "Next step"
+msgstr ""
+
+#: src/components/answer/AnswerPage.js:301
 msgid "No options chosen"
 msgstr ""
 
@@ -371,6 +390,11 @@ msgid "You need to log in to access this page"
 msgstr ""
 
 #: src/components/answer/AnswerPage.js:205
+#: src/components/creation/timeslots/TimeslotsStep.js:37
+msgid "You haven't added any slots yet"
+msgstr ""
+
+#: src/components/answer/AnswerPage.js:206
 msgid "Your answer has been saved!"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Awaiting your reply"
 msgstr ""
 
-#: src/components/creation/timeslots/TimeslotsStep.js:66
+#: src/components/creation/timeslots/TimeslotsStep.js:61
 msgid "Back"
 msgstr ""
 
@@ -231,7 +231,7 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#: src/components/creation/timeslots/TimeslotsStep.js:76
+#: src/components/creation/timeslots/TimeslotsStep.js:71
 msgid "Next step"
 msgstr ""
 
@@ -374,10 +374,6 @@ msgstr ""
 msgid "You can use it to find out the best dates/times for your meetings."
 msgstr "Puedes usarlo para conocer los mejores dias/fechas para tus reuniones."
 
-#: src/components/creation/timeslots/TimeslotsStep.js:37
-msgid "You haven't added any slots yet"
-msgstr ""
-
 #: src/components/login/LoginPrompt.js:40
 msgid "You need to log in to access this page"
 msgstr ""
@@ -459,8 +455,8 @@ msgstr ""
 msgid "{hours}h {minutes}min"
 msgstr ""
 
-#: src/components/creation/timeslots/TimeslotsStep.js:22
-msgid "{numSlots, plural, one {<0>#</0> slot added } other {<1>#</1> slots added }}"
+#: src/components/creation/timeslots/TimeslotsStep.js:21
+msgid "{numSlots, plural, one {<0>#</0> slot added } other {<1>#</1> slots added } =0 {You haven't added any slots yet}}"
 msgstr ""
 
 #: src/components/answer/AnswerPage.js:292

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -13,10 +13,6 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/creation/timeslots/TimeslotsStep.js:24
-msgid "<0>1</0> slot added"
-msgstr ""
-
 #: src/components/home/HomeHeader.js:11
 msgid "<0>newdle</0> is a collective meeting scheduling application."
 msgstr "<0>newdle</0> es una aplicación para programar reuniones colectivamente."
@@ -24,10 +20,6 @@ msgstr "<0>newdle</0> es una aplicación para programar reuniones colectivamente
 #: src/components/home/HomePage.js:38
 msgid "<0>newdle</0> will collect the answers!"
 msgstr "<0>newdle</0> guardará las respuestas"
-
-#: src/components/creation/timeslots/TimeslotsStep.js:30
-msgid "<0>{numSlots}</0> slots added"
-msgstr ""
 
 #: src/components/answer/AnswerPage.js:232
 msgid "Accept all options where I'm available"
@@ -465,6 +457,10 @@ msgstr ""
 
 #: src/components/creation/timeslots/DurationPicker.js:25
 msgid "{hours}h {minutes}min"
+msgstr ""
+
+#: src/components/creation/timeslots/TimeslotsStep.js:22
+msgid "{numSlots, plural, one {<0>#</0> slot added } other {<1>#</1> slots added }}"
 msgstr ""
 
 #: src/components/answer/AnswerPage.js:292

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -25,12 +25,11 @@ msgstr "<0>newdle</0> es una aplicación para programar reuniones colectivamente
 msgid "<0>newdle</0> will collect the answers!"
 msgstr "<0>newdle</0> guardará las respuestas"
 
-#: src/components/answer/AnswerPage.js:232
 #: src/components/creation/timeslots/TimeslotsStep.js:30
 msgid "<0>{numSlots}</0> slots added"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:233
+#: src/components/answer/AnswerPage.js:232
 msgid "Accept all options where I'm available"
 msgstr ""
 
@@ -66,14 +65,13 @@ msgstr ""
 msgid "Awaiting your reply"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:136
-#: src/components/login/LoginPrompt.js:45
-#: src/components/summary/SummaryPage.js:165
 #: src/components/creation/timeslots/TimeslotsStep.js:66
 msgid "Back"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:166
+#: src/components/creation/userSearch/UserSearch.js:136
+#: src/components/login/LoginPrompt.js:45
+#: src/components/summary/SummaryPage.js:165
 msgid "Cancel"
 msgstr ""
 
@@ -241,16 +239,15 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
+#: src/components/creation/timeslots/TimeslotsStep.js:76
+msgid "Next step"
+msgstr ""
+
 #: src/components/answer/Calendar.js:210
 msgid "No data"
 msgstr ""
 
 #: src/components/answer/AnswerPage.js:300
-#: src/components/creation/timeslots/TimeslotsStep.js:76
-msgid "Next step"
-msgstr ""
-
-#: src/components/answer/AnswerPage.js:301
 msgid "No options chosen"
 msgstr ""
 
@@ -385,16 +382,15 @@ msgstr ""
 msgid "You can use it to find out the best dates/times for your meetings."
 msgstr "Puedes usarlo para conocer los mejores dias/fechas para tus reuniones."
 
+#: src/components/creation/timeslots/TimeslotsStep.js:37
+msgid "You haven't added any slots yet"
+msgstr ""
+
 #: src/components/login/LoginPrompt.js:40
 msgid "You need to log in to access this page"
 msgstr ""
 
 #: src/components/answer/AnswerPage.js:205
-#: src/components/creation/timeslots/TimeslotsStep.js:37
-msgid "You haven't added any slots yet"
-msgstr ""
-
-#: src/components/answer/AnswerPage.js:206
 msgid "Your answer has been saved!"
 msgstr ""
 


### PR DESCRIPTION
Closes #285 

I had to use Trans instead of Plural for numSlots as there was an html tag **strong** required for the numSlots value. 
Plural component's props _other_ takes in a string and if I pass in the **strong** tag, it renders as a string on the web page. I could have set a variable to JSX element with the **strong** tag and used that to render the _other_ prop using Plural, but I saw that the messages.po file picks up the variable name rather than the actual text. 

I tried multiple other variations but was unable to find a solution utilizing Plural. 