### PR TITLE
Proxy gravatar requests via newdle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ PYTHON=/usr/bin/python3.8 make
 
 ## Database schema
 
-Before running the alembic migrations make sure you  have created a database called `newdle` (or adjust the config file). Having done that, run `flask db upgrade` to upgrade the schema.
+Before running the alembic migrations make sure you have created a database called `newdle` (or adjust the config file). Having done that, run `flask db upgrade` to upgrade the schema.
 
 ## Running the development server
 

--- a/newdle/api.py
+++ b/newdle/api.py
@@ -86,6 +86,8 @@ def require_token():
 @allow_anonymous
 def user_avatar(payload):
     user_info = avatar_info_from_payload(payload)
+    if user_info is None:
+        abort(404)
     size = request.args.get('size')
     email_hex = hashlib.md5(user_info['email'].lower().encode()).hexdigest()
     # make gravatar return 404 HTTP code instead of a default image

--- a/newdle/client/package-lock.json
+++ b/newdle/client/package-lock.json
@@ -4248,11 +4248,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -4905,11 +4900,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -8857,11 +8847,6 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
     },
-    "is-retina": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-retina/-/is-retina-1.0.3.tgz",
-      "integrity": "sha1-10AbKGvqKuN/Ykd1iN5QTQuGR+M="
-    },
     "is-root": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
@@ -10051,16 +10036,6 @@
       "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
       "requires": {
         "css-mediaquery": "^0.1.2"
-      }
-    },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
       }
     },
     "md5.js": {
@@ -13380,16 +13355,6 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
           "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
-      }
-    },
-    "react-gravatar": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/react-gravatar/-/react-gravatar-2.6.3.tgz",
-      "integrity": "sha1-VAfrash+gw4qNN63YNKkxATrHaw=",
-      "requires": {
-        "is-retina": "^1.0.3",
-        "md5": "^2.1.0",
-        "query-string": "^4.2.2"
       }
     },
     "react-is": {

--- a/newdle/client/package.json
+++ b/newdle/client/package.json
@@ -19,7 +19,6 @@
     "react-dates": "^21.8.0",
     "react-dom": "^16.13.1",
     "react-final-form": "^6.5.1",
-    "react-gravatar": "^2.6.3",
     "react-redux": "^7.2.1",
     "react-responsive": "^8.1.0",
     "react-router": "^5.2.0",

--- a/newdle/client/src/components/UserAvatar.js
+++ b/newdle/client/src/components/UserAvatar.js
@@ -1,27 +1,19 @@
 import React from 'react';
-import Gravatar from 'react-gravatar';
 import PropTypes from 'prop-types';
 import {Popup} from 'semantic-ui-react';
 
 const DEFAULT_AVATAR_SIZE = 42;
-const defaultArgs = [
-  'f0e9e9', // background
-  '8b5d5d', // color
-  2, // length
-  0.5, // font size
-  true, // rounded
-].join('/');
 
-function UserAvatar({user: {email, name}, className, withLabel, size}) {
-  const uri = `https://ui-avatars.com/api/${name[0]}/${size}/${defaultArgs}`;
-
+function UserAvatar({user: {name, avatar_url}, className, withLabel, size}) {
+  const avatarURL = new URL(avatar_url, window.location.origin);
+  avatarURL.searchParams.set('size', size);
   return (
     <div className={className}>
       {withLabel && <span>{name}</span>}{' '}
       <Popup
         position="top center"
         mouseEnterDelay={100}
-        trigger={<Gravatar email={email} default={encodeURI(uri)} size={size} />}
+        trigger={<img className="user-avatar" src={avatarURL} alt="" />}
         content={name}
         disabled={withLabel}
       />

--- a/newdle/client/src/components/creation/userSearch/UserSearch.js
+++ b/newdle/client/src/components/creation/userSearch/UserSearch.js
@@ -82,7 +82,7 @@ export default function UserSearch() {
                   <List.Icon verticalAlign="middle">
                     <UserAvatar
                       user={participant}
-                      size={35}
+                      size={30}
                       className={styles['participant-avatar']}
                     />
                   </List.Icon>

--- a/newdle/client/src/components/creation/userSearch/UserSearch.module.scss
+++ b/newdle/client/src/components/creation/userSearch/UserSearch.module.scss
@@ -20,7 +20,7 @@
   }
 }
 
-.participant-avatar img:global(.react-gravatar) {
+.participant-avatar img:global(.user-avatar) {
   border-radius: 50%;
 }
 

--- a/newdle/core/auth.py
+++ b/newdle/core/auth.py
@@ -1,7 +1,7 @@
 from flask import current_app, render_template
 from flask_multipass import Multipass
-from itsdangerous import URLSafeTimedSerializer
-from werkzeug.local import LocalProxy
+
+from .util import secure_timed_serializer
 
 
 class NewdleMultipass(Multipass):
@@ -11,10 +11,6 @@ class NewdleMultipass(Multipass):
 
 
 multipass = NewdleMultipass()
-
-secure_serializer = LocalProxy(
-    lambda: URLSafeTimedSerializer(current_app.config['SECRET_KEY'], b'newdle')
-)
 
 
 @multipass.identity_handler
@@ -26,7 +22,7 @@ def process_identity(identity_info):
 
 
 def app_token_from_multipass(identity_info):
-    return secure_serializer.dumps(
+    return secure_timed_serializer.dumps(
         {
             'email': identity_info.data['email'],
             'first_name': identity_info.data['given_name'],
@@ -38,7 +34,7 @@ def app_token_from_multipass(identity_info):
 
 
 def app_token_from_dummy():
-    return secure_serializer.dumps(
+    return secure_timed_serializer.dumps(
         {
             'email': 'example@example.com',
             'first_name': 'Guinea',
@@ -50,7 +46,7 @@ def app_token_from_dummy():
 
 
 def user_info_from_app_token(app_token):
-    return secure_serializer.loads(
+    return secure_timed_serializer.loads(
         app_token, salt='app-token', max_age=current_app.config['TOKEN_LIFETIME']
     )
 

--- a/newdle/core/util.py
+++ b/newdle/core/util.py
@@ -4,7 +4,7 @@ from enum import Enum
 from io import BytesIO
 
 from flask import current_app, render_template, send_file
-from itsdangerous import Signer, URLSafeSerializer, URLSafeTimedSerializer
+from itsdangerous import BadData, Signer, URLSafeSerializer, URLSafeTimedSerializer
 from werkzeug.local import LocalProxy
 
 
@@ -117,4 +117,7 @@ def avatar_payload_from_user_info(user_info):
 
 
 def avatar_info_from_payload(payload):
-    return secure_serializer.loads(payload, salt='avatar-payload')
+    try:
+        return secure_serializer.loads(payload, salt='avatar-payload')
+    except BadData:
+        return None

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -12,7 +12,11 @@ from marshmallow_enum import EnumField
 from pytz import common_timezones_set
 
 from .core.marshmallow import mm
-from .core.util import DATETIME_FORMAT, check_user_signature
+from .core.util import (
+    DATETIME_FORMAT,
+    avatar_payload_from_user_info,
+    check_user_signature,
+)
 from .models import Availability
 
 
@@ -20,11 +24,16 @@ class UserSchema(mm.Schema):
     email = fields.String()
     name = fields.Function(lambda u: f'{u["first_name"]} {u["last_name"]}')
     uid = fields.String()
+    avatar_url = fields.Function(
+        lambda user: url_for(
+            'api.user_avatar', payload=avatar_payload_from_user_info(user)
+        )
+    )
 
 
 class UserSearchResultSchema(UserSchema):
     class Meta:
-        fields = ('email', 'name', 'uid')
+        fields = ('email', 'name', 'uid', 'avatar_url')
 
     @post_dump(pass_many=True)
     def sort_users(self, data, many, **kwargs):

--- a/newdle/templates/avatar.svg
+++ b/newdle/templates/avatar.svg
@@ -1,0 +1,5 @@
+<svg height="{{ size }}" width="{{ size }}" xmlns="http://www.w3.org/2000/svg" style="background-color: #f0e9e9;">
+  <text x="50%" y="53%" dominant-baseline="middle" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="20" fill="#8b5d5d">
+    {{ text | escape }}
+  </text>
+</svg>

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import Forbidden
 
 from newdle import api
 from newdle.core.auth import app_token_from_multipass
+from newdle.core.util import avatar_payload_from_user_info
 from newdle.models import Newdle, Participant
 
 
@@ -38,6 +39,13 @@ def test_me(flask_client, dummy_uid):
         'email': 'example@example.com',
         'name': 'Guinea Pig',
         'uid': 'user123',
+        'avatar_url': url_for(
+            'api.user_avatar',
+            payload=avatar_payload_from_user_info(
+                {'email': 'example@example.com', 'first_name': 'Guinea'}
+            ),
+            _external=False,
+        ),
     }
 
 


### PR DESCRIPTION
One thing to consider:

- [x] right now, all the requests to `/api/avatar/<email>` don't require authentication which is not ideal. It is not possible to attach the `Authorization` header when fetching the image, thus maybe it could be a good idea to put the token in a cookie?  

closes #139 