### PR TITLE
Update to nodejs 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # builder image
 FROM python:3.8 AS builder
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 ADD . /build/


### PR DESCRIPTION
Related to #246

We can upgrade this to node 14, as we've been using it for quite some time now and the node-sass doesn't support it anymore (4.14+).