### PR TITLE
Get rid of split names (first + last)

### DIFF
--- a/newdle/api.py
+++ b/newdle/api.py
@@ -152,20 +152,15 @@ def _generate_fake_users():
     f.seed_instance(0)
 
     def _generate_fake_user():
-        first_name = f.first_name()
-        last_name = f.last_name()
-        email = f'{first_name}.{last_name}@{f.domain_name()}'.lower()
         return {
-            'first_name': first_name,
-            'last_name': last_name,
-            'email': email,
+            'name': f.name(),
+            'email': f.free_email(),
             'uid': str(uuid.uuid4()),
         }
 
     return [_generate_fake_user() for _ in range(100)] + [
         {
-            'first_name': g.user['first_name'],
-            'last_name': g.user['last_name'],
+            'name': g.user['name'],
             'email': g.user['email'],
             'uid': g.user['uid'],
         }
@@ -177,7 +172,7 @@ def _match(user, name, email):
     if email and email not in user['email']:
         return False
     parts = name.lower().split() if name else []
-    name = f'{user["first_name"]} {user["last_name"]}'.lower()
+    name = user['name'].lower()
     return all(p in name for p in parts)
 
 
@@ -297,7 +292,7 @@ def create_newdle(title, duration, timezone, timeslots, participants, private, n
     newdle = Newdle(
         title=title,
         creator_uid=g.user['uid'],
-        creator_name=f'{g.user["first_name"]} {g.user["last_name"]}',
+        creator_name=g.user['name'],
         creator_email=g.user['email'],
         duration=duration,
         timezone=timezone,
@@ -487,13 +482,12 @@ def create_participant(code):
     newdle = Newdle.query.filter_by(code=code).first_or_404(
         'Specified newdle does not exist'
     )
-    name = f'{g.user["first_name"]} {g.user["last_name"]}'
     participant = Participant.query.filter_by(
         newdle=newdle, auth_uid=g.user['uid']
     ).first()
     if not participant:
         participant = Participant(
-            name=name, email=g.user['email'], auth_uid=g.user['uid']
+            name=g.user['name'], email=g.user['email'], auth_uid=g.user['uid']
         )
         newdle.participants.add(participant)
         newdle.update_lastmod()

--- a/newdle/core/app.py
+++ b/newdle/core/app.py
@@ -40,8 +40,6 @@ def _configure_multipass(app):
     app.config['MULTIPASS_PROVIDER_MAP'] = {'newdle-sso': 'newdle-sso'}
     app.config['MULTIPASS_IDENTITY_INFO_KEYS'] = {
         'email',
-        'given_name',
-        'family_name',
         'name',
     }
     multipass.init_app(app)

--- a/newdle/core/auth.py
+++ b/newdle/core/auth.py
@@ -25,8 +25,7 @@ def app_token_from_multipass(identity_info):
     return secure_timed_serializer.dumps(
         {
             'email': identity_info.data['email'],
-            'first_name': identity_info.data['given_name'],
-            'last_name': identity_info.data['family_name'],
+            'name': identity_info.data['name'],
             'uid': identity_info.identifier,
         },
         salt='app-token',
@@ -37,8 +36,7 @@ def app_token_from_dummy():
     return secure_timed_serializer.dumps(
         {
             'email': 'example@example.com',
-            'first_name': 'Guinea',
-            'last_name': 'Pig',
+            'name': 'Guinea Pig',
             'uid': '-',
         },
         salt='app-token',
@@ -64,8 +62,7 @@ def search_users(name, email, limit):
     users = [
         {
             'email': identity.data['email'],
-            'first_name': identity.data['given_name'],
-            'last_name': identity.data['family_name'],
+            'name': identity.data['name'],
             'uid': identity.identifier,
         }
         for identity in sorted(identities, key=lambda x: x.data['name'])

--- a/newdle/core/util.py
+++ b/newdle/core/util.py
@@ -110,7 +110,7 @@ def avatar_payload_from_user_info(user_info):
     return secure_serializer.dumps(
         {
             'email': user_info['email'],
-            'initial': user_info['first_name'][0].upper(),
+            'initial': user_info['name'][0].upper(),
         },
         salt='avatar-payload',
     )

--- a/newdle/newdle.cfg.example
+++ b/newdle/newdle.cfg.example
@@ -22,7 +22,7 @@ MULTIPASS_AUTH_PROVIDER_LOGIN = {
 }
 
 # The Flask-Multipass identity provider settings. Currently only one provider is supported
-# and it needs to provide the following data keys: email, given_name, family_name, name
+# and it needs to provide the following data keys: email, name
 MULTIPASS_IDENTITY_PROVIDER_LOGIN = {'type': 'authlib'}
 
 # The Flask-Multipass identity provider settings used to search for existing people.

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -25,7 +25,7 @@ from .models import Availability
 
 class UserSchema(mm.Schema):
     email = fields.String()
-    name = fields.Function(lambda u: f'{u["first_name"]} {u["last_name"]}')
+    name = fields.String()
     uid = fields.String()
     avatar_url = fields.Function(
         lambda user: url_for(

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -44,8 +44,7 @@ def make_test_auth(uid):
         identifier=uid,
         data={
             'email': 'example@example.com',
-            'given_name': 'Guinea',
-            'family_name': 'Pig',
+            'name': 'Guinea Pig',
         },
     )
     token = app_token_from_multipass(mock_identity_info)
@@ -69,7 +68,7 @@ def test_me(flask_client, dummy_uid):
         'avatar_url': url_for(
             'api.user_avatar',
             payload=avatar_payload_from_user_info(
-                {'email': 'example@example.com', 'first_name': 'Guinea'}
+                {'email': 'example@example.com', 'name': 'Guinea Pig'}
             ),
             _external=False,
         ),


### PR DESCRIPTION
It's not a given that the auth provider will split "first" and "last" names. Moreover, there is no added value in having those in newdle. So, I suggest we just get rid of them.