### PR TITLE
Fix previous newdle data leaking into newdle creation

### DIFF
--- a/newdle/client/src/components/summary/SummaryHeader.js
+++ b/newdle/client/src/components/summary/SummaryHeader.js
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
-import {clearNewdle, fetchNewdle} from '../../actions';
+import {abortCreation, clearNewdle, fetchNewdle} from '../../actions';
 import {getNewdle} from '../../selectors';
 import NewdleTitle from '../NewdleTitle';
 
@@ -15,6 +15,7 @@ export default function SummaryHeader({match}) {
 
     return () => {
       dispatch(clearNewdle());
+      dispatch(abortCreation());
     };
   }, [code, dispatch]);
 


### PR DESCRIPTION
Closes #355

When a user visits a specific newdle (`/newdle/{code}/summary`), some data is automatically prefilled in the `creation`
redux state. If the user goes back to `/mine` and creates a new newdle, this data is not properly removed.

This PR adds a call to `abortCreation` when newdle summary is unmounted, which clears the state.