### PR TITLE
Request an extra week of free-busy data with OX

### DIFF
--- a/newdle/newdle.cfg.example
+++ b/newdle/newdle.cfg.example
@@ -99,6 +99,9 @@ EXCHANGE_PROVIDER_CREDENTIALS = ('', '')
 # OX_PROVIDER_CONTEXT_ID = 1
 # Maximum amount of weeks into the future to fetch allowed by the provider (optional, defaults to 4)
 # https://documentation.open-xchange.com/components/middleware/rest/7.10.4/index.html#!InternetFreeBusy/getFreeBusy
+# OX cuts off the last day so that the duration is exactly the number of weeks instead of
+# providing data until 23:59 of the last day. To cover the last day, newdle requests data for an extra week.
+# For this reason, this setting should be 1 greater than the effective number of weeks.
 # OX_PROVIDER_MAX_WEEKS = 4
 OX_PROVIDER_URL = ''
 OX_PROVIDER_USERNAME = ''

--- a/newdle/providers/free_busy/ox.py
+++ b/newdle/providers/free_busy/ox.py
@@ -23,6 +23,11 @@ def fetch_free_busy(date, tz, uid, email):
 
     # see how far into the future we have to fetch data
     weeks_to_fetch = math.ceil((date - datetime.now().date()).days / 7) or 1
+    # OX gives free-busy data for exactly the number of weeks,
+    # which cuts off the last day instead of showing data until 23:59.
+    # To get the full day, we request an additional week.
+    # https://github.com/indico/newdle/issues/365
+    weeks_to_fetch += 1
 
     if weeks_to_fetch > ox_max_weeks:
         return []


### PR DESCRIPTION
Closes #365 

OX cuts of the last day of the week instead of showing the full day until 23:59.
To get the data for the entire day, we request an extra week from OX.

With this change, we'll have to increment `OX_PROVIDER_MAX_WEEKS` in `newdle.cfg`.