### PR TITLE
Make it less likely for people to share their personal participant link

### DIFF
--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -3,7 +3,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import {useHistory, useRouteMatch} from 'react-router';
 import {Trans, t} from '@lingui/macro';
 import PropTypes from 'prop-types';
-import {Container, Icon, Button, Popup} from 'semantic-ui-react';
+import {Container, Icon, Button, Popup, Divider} from 'semantic-ui-react';
 import {useIsMobile} from 'src/util/hooks';
 import {toggleGridView} from '../actions';
 import {getGridViewActive, getStoredParticipantCodeForNewdle} from '../answerSelectors';
@@ -16,6 +16,7 @@ export default function NewdleTitle({
   creatorUid,
   finished,
   code,
+  url,
   isPrivate,
   isDeleted,
 }) {
@@ -111,6 +112,38 @@ export default function NewdleTitle({
           )}
         </div>
       </div>
+      {(isCreator || participantCode) && (
+        <>
+          <Divider fitted />
+          <div className={styles['shareable-link']}>
+            <div className={styles['legend']}>
+              <Trans>Shareable link</Trans>
+            </div>
+            <div>
+              <Icon name="linkify" size="small" color="grey" disabled />
+              {url}
+            </div>
+            {navigator.clipboard && (
+              <Popup
+                content={t`Copied!`}
+                on="click"
+                position="top center"
+                inverted
+                trigger={
+                  <Icon
+                    name="copy"
+                    title={t`Copy to clipboard`}
+                    onClick={() => navigator.clipboard.writeText(url)}
+                    size="small"
+                    color="grey"
+                    link
+                  />
+                }
+              />
+            )}
+          </div>
+        </>
+      )}
     </Container>
   );
 }
@@ -122,6 +155,7 @@ NewdleTitle.propTypes = {
   label: PropTypes.string,
   finished: PropTypes.bool,
   code: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
   isPrivate: PropTypes.bool,
   isDeleted: PropTypes.bool,
 };

--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -119,27 +119,27 @@ export default function NewdleTitle({
             <div className={styles['legend']}>
               <Trans>Shareable link</Trans>
             </div>
-            <div>
-              <Icon name="linkify" size="small" color="grey" disabled />
-              {url}
-            </div>
-            {navigator.clipboard && (
+            {navigator.clipboard ? (
               <Popup
                 content={t`Copied!`}
                 on="click"
                 position="top center"
                 inverted
                 trigger={
-                  <Icon
-                    name="copy"
+                  <a
+                    href={url}
                     title={t`Copy to clipboard`}
-                    onClick={() => navigator.clipboard.writeText(url)}
-                    size="small"
-                    color="grey"
-                    link
-                  />
+                    onClick={evt => {
+                      navigator.clipboard.writeText(url);
+                      evt.preventDefault();
+                    }}
+                  >
+                    {url}
+                  </a>
                 }
               />
+            ) : (
+              url
             )}
           </div>
         </>

--- a/newdle/client/src/components/NewdleTitle.module.scss
+++ b/newdle/client/src/components/NewdleTitle.module.scss
@@ -36,4 +36,19 @@
   .navigation {
     padding-right: 6px;
   }
+
+  .shareable-link {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 1em;
+    align-items: center;
+    margin-top: 0.5em;
+    font-size: 9pt;
+    color: $grey;
+
+    .legend {
+      font-weight: 700;
+    }
+  }
 }

--- a/newdle/client/src/components/answer/AnswerHeader.js
+++ b/newdle/client/src/components/answer/AnswerHeader.js
@@ -50,6 +50,7 @@ export default function AnswerHeader({match}) {
       creatorUid={newdle.creator_uid}
       finished={!!newdle.final_dt}
       code={newdle.code}
+      url={newdle.url}
       isPrivate={newdle.private}
       isDeleted={newdle.deleted}
     />

--- a/newdle/client/src/components/answer/AnswerPage.js
+++ b/newdle/client/src/components/answer/AnswerPage.js
@@ -314,6 +314,16 @@ export default function AnswerPage() {
             </p>
           </Message>
         )}
+        {participant && (
+          <Message warning>
+            <p>
+              <Trans>
+                This page is personal and its URL should not be shared. Please use the shareable
+                link above to share the newdle with others.
+              </Trans>
+            </p>
+          </Message>
+        )}
       </div>
       {(!gridViewActive || unknown) && (
         <Grid container style={{marginTop: '14px'}}>

--- a/newdle/client/src/components/summary/SummaryHeader.js
+++ b/newdle/client/src/components/summary/SummaryHeader.js
@@ -30,6 +30,7 @@ export default function SummaryHeader({match}) {
       creatorUid={newdle.creator_uid}
       finished={!!newdle.final_dt}
       code={newdle.code}
+      url={newdle.url}
       isPrivate={newdle.private}
       isDeleted={newdle.deleted}
     />

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -45,7 +45,7 @@ msgstr ""
 msgid "All participants answered."
 msgstr ""
 
-#: src/components/NewdleTitle.js:61
+#: src/components/NewdleTitle.js:62
 msgid "Answer newdle"
 msgstr ""
 
@@ -110,6 +110,7 @@ msgstr ""
 msgid "Confirm changes"
 msgstr ""
 
+#: src/components/NewdleTitle.js:128
 #: src/components/creation/CreationSuccessPage.js:59
 msgid "Copied!"
 msgstr ""
@@ -118,6 +119,7 @@ msgstr ""
 msgid "Copy time slots from previous day"
 msgstr ""
 
+#: src/components/NewdleTitle.js:135
 #: src/components/creation/CreationSuccessPage.js:66
 msgid "Copy to clipboard"
 msgstr ""
@@ -331,6 +333,10 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
+#: src/components/NewdleTitle.js:120
+msgid "Shareable link"
+msgstr ""
+
 #: src/components/creation/ParticipantsStep.js:44
 msgid "Skip"
 msgstr ""
@@ -361,7 +367,7 @@ msgstr ""
 msgid "They will be presented as options to the participants"
 msgstr ""
 
-#: src/components/NewdleTitle.js:61
+#: src/components/NewdleTitle.js:62
 #: src/components/answer/AnswerPage.js:222
 msgid "This newdle has already finished"
 msgstr ""
@@ -383,7 +389,7 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/components/NewdleTitle.js:93
+#: src/components/NewdleTitle.js:94
 msgid "Toggle grid view"
 msgstr ""
 
@@ -391,7 +397,7 @@ msgstr ""
 msgid "Update your answer"
 msgstr ""
 
-#: src/components/NewdleTitle.js:76
+#: src/components/NewdleTitle.js:77
 msgid "View summary"
 msgstr ""
 
@@ -443,7 +449,7 @@ msgstr ""
 msgid "Your session expired"
 msgstr ""
 
-#: src/components/NewdleTitle.js:54
+#: src/components/NewdleTitle.js:55
 msgid "by {author}"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -381,6 +381,10 @@ msgstr ""
 msgid "This newdle has finished"
 msgstr ""
 
+#: src/components/answer/AnswerPage.js:312
+msgid "This page is personal and its URL should not be shared. Please use the shareable link above to share the newdle with others."
+msgstr ""
+
 #: src/components/summary/SummaryPage.js:284
 msgid "Timeslots"
 msgstr ""

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -110,7 +110,7 @@ msgstr ""
 msgid "Confirm changes"
 msgstr ""
 
-#: src/components/NewdleTitle.js:128
+#: src/components/NewdleTitle.js:124
 #: src/components/creation/CreationSuccessPage.js:59
 msgid "Copied!"
 msgstr ""
@@ -119,7 +119,7 @@ msgstr ""
 msgid "Copy time slots from previous day"
 msgstr ""
 
-#: src/components/NewdleTitle.js:135
+#: src/components/NewdleTitle.js:131
 #: src/components/creation/CreationSuccessPage.js:66
 msgid "Copy to clipboard"
 msgstr ""
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Leave a comment (optional)"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:377
+#: src/components/answer/AnswerPage.js:387
 msgid "Leave a comment..."
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr ""
 msgid "No data"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:371
+#: src/components/answer/AnswerPage.js:381
 msgid "No options chosen"
 msgstr ""
 
@@ -325,7 +325,7 @@ msgstr ""
 msgid "Select your language"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:392
+#: src/components/answer/AnswerPage.js:402
 msgid "Send your answer"
 msgstr ""
 
@@ -381,7 +381,7 @@ msgstr ""
 msgid "This newdle has finished"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:312
+#: src/components/answer/AnswerPage.js:320
 msgid "This page is personal and its URL should not be shared. Please use the shareable link above to share the newdle with others."
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Toggle grid view"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:392
+#: src/components/answer/AnswerPage.js:402
 msgid "Update your answer"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "{numSlots, plural, one {<0>#</0> slot selected} other {<1>#</1> slots selected} =0 {You haven't selected any slots yet}}"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:363
+#: src/components/answer/AnswerPage.js:373
 msgid "{numberOfTimeslots, plural, one {{numberOfAvailable} out of # option chosen} other {{numberOfAvailable} out of # options chosen}}"
 msgstr ""
 


### PR DESCRIPTION
Closes #378

This PR makes the newdle's shareable link more prominent to avoid people copying the URL from the address bar.

<img width="954" alt="image" src="https://user-images.githubusercontent.com/27357203/164019360-76877741-f96e-432a-9508-ebd84849cc67.png">