### PR TITLE
Add option to clone newdles

### DIFF
--- a/newdle/client/src/components/App.js
+++ b/newdle/client/src/components/App.js
@@ -5,7 +5,7 @@ import {i18n} from '@lingui/core';
 import {I18nProvider} from '@lingui/react';
 import {isLoginWindowOpen, getErrors} from '../selectors';
 import {AnswerPage} from './answer';
-import {CreationPage, CreationSuccessPage, EditPage} from './creation';
+import {CreationPage, CreationSuccessPage, EditPage, ClonePage} from './creation';
 import ErrorMessage from './ErrorMessage';
 import Footer from './Footer';
 import {HomePage} from './home';
@@ -39,6 +39,7 @@ export default function App() {
               <Route exact path="/participating" component={NewdlesParticipating} />
               <Route exact path="/newdle/:code/summary" component={SummaryPage} />
               <Route path="/newdle/:code/edit" component={EditPage} />
+              <Route path="/newdle/:code/clone" component={ClonePage} />
               <Route exact path="/newdle/:code/:partcode?" component={AnswerPage} />
               <Route render={() => <div>This page does not exist</div>} />
             </Switch>

--- a/newdle/client/src/components/MyNewdles.js
+++ b/newdle/client/src/components/MyNewdles.js
@@ -14,7 +14,7 @@ import styles from './MyNewdles.module.scss';
 export default function MyNewdles() {
   const [newdles, loading] = client.useBackend(() => client.getMyNewdles(), []);
   const dispatch = useDispatch();
-  usePageTitle('My newdles');
+  usePageTitle(t`My newdles`);
 
   useEffect(() => {
     // this avoids getting an unexpected previous participant in this particular edge case:

--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -112,7 +112,7 @@ export default function NewdleTitle({
           )}
         </div>
       </div>
-      {(isCreator || participantCode) && (
+      {(isCreator || participantCode) && !isDeleted && (
         <>
           <Divider fitted />
           <div className={styles['shareable-link']}>
@@ -155,7 +155,7 @@ NewdleTitle.propTypes = {
   label: PropTypes.string,
   finished: PropTypes.bool,
   code: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
+  url: PropTypes.string,
   isPrivate: PropTypes.bool,
   isDeleted: PropTypes.bool,
 };
@@ -165,4 +165,5 @@ NewdleTitle.defaultProps = {
   finished: null,
   isDeleted: false,
   isPrivate: true,
+  url: null,
 };

--- a/newdle/client/src/components/NewdlesParticipating.js
+++ b/newdle/client/src/components/NewdlesParticipating.js
@@ -11,7 +11,7 @@ import styles from './MyNewdles.module.scss';
 
 export default function NewdlesParticipating() {
   const [participations, loading] = client.useBackend(() => client.getNewdlesParticipating(), []);
-  usePageTitle("Newdles I'm participating in");
+  usePageTitle(t`Newdles I'm participating in`);
 
   let content;
   if (loading || participations === null) {

--- a/newdle/client/src/components/answer/AnswerHeader.js
+++ b/newdle/client/src/components/answer/AnswerHeader.js
@@ -2,13 +2,7 @@ import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
 import {getUserInfo} from 'src/selectors';
-import {
-  abortAnswering,
-  fetchNewdleForAnswer,
-  clearNewdle,
-  fetchNewdle,
-  abortCreation,
-} from '../../actions';
+import {abortAnswering, fetchNewdleForAnswer, clearNewdle, fetchNewdle} from '../../actions';
 import {getNewdle} from '../../answerSelectors';
 import NewdleTitle from '../NewdleTitle';
 
@@ -23,7 +17,6 @@ export default function AnswerHeader({match}) {
 
     return () => {
       dispatch(abortAnswering());
-      dispatch(abortCreation());
     };
   }, [code, dispatch]);
 

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -25,6 +25,7 @@ export default function EditPage() {
   const isUserLoggedIn = useSelector(isLoggedIn);
   const newdle = useSelector(getCreatedNewdle);
   const history = useHistory();
+  const [keepSettings, setKeepSettings] = useState(true);
   const [keepParticipants, setKeepParticipants] = useState(true);
   const [keepTimeslots, setKeepTimeslots] = useState(true);
   const [option, setOption] = useState('keep');
@@ -43,8 +44,17 @@ export default function EditPage() {
     history.push({
       pathname: `/new`,
       state: {
-        participants: keepParticipants ? newdle.participants : [],
-        timeslots: keepTimeslots ? moveTimeslots(newdle.timeslots, newdle.timezone, dayOffset) : [],
+        cloneData: {
+          duration: newdle.duration,
+          timezone: newdle.timezone,
+          title: keepSettings ? newdle.title : null,
+          private: keepSettings ? newdle.private : null,
+          notify: keepSettings ? newdle.notify : null,
+          participants: keepParticipants ? newdle.participants : [],
+          timeslots: keepTimeslots
+            ? moveTimeslots(newdle.timeslots, newdle.timezone, dayOffset)
+            : [],
+        },
       },
     });
   }
@@ -64,7 +74,7 @@ export default function EditPage() {
     <Trans>Keep the timeslots as they are</Trans>
   );
 
-  const canSubmit = option !== 1 || startDate !== '';
+  const canSubmit = keepSettings || keepParticipants || keepTimeslots;
 
   return (
     <Container text>
@@ -76,8 +86,20 @@ export default function EditPage() {
         </div>
         <div className={styles['options']}>
           <div>
+            <label htmlFor="keepSettings">
+              <Trans>Keep title and settings</Trans>
+            </label>
+            <Checkbox
+              className={styles['advanced-checkbox']}
+              id="keepSettings"
+              toggle
+              checked={keepSettings}
+              onChange={(_, {checked}) => setKeepSettings(checked)}
+            />
+          </div>
+          <div>
             <label htmlFor="keepParticipants">
-              <Trans>Keep the list of participants</Trans>
+              <Trans>Keep list of participants</Trans>
             </label>
             <Checkbox
               className={styles['advanced-checkbox']}

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -29,7 +29,7 @@ export default function EditPage() {
   const [keepTimeslots, setKeepTimeslots] = useState(true);
   const [option, setOption] = useState('keep');
   const [startDate, setStartDate] = useState('');
-  usePageTitle('Cloning newdle');
+  usePageTitle(t`Cloning newdle`);
 
   if (!isUserLoggedIn) {
     return <Redirect to="/" />;

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -31,7 +31,7 @@ export default function ClonePage() {
   const [keepTimeslots, setKeepTimeslots] = useState(true);
   const [option, setOption] = useState('keep');
   const [startDate, setStartDate] = useState(serializeDate(moment()));
-  usePageTitle(t`Cloning newdle`);
+  usePageTitle(t`Clone newdle`);
 
   if (!isUserLoggedIn) {
     return <Redirect to="/" />;

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -112,7 +112,7 @@ export default function ClonePage() {
                 <>
                   <Trans>Keep list of participants</Trans>
                   <Popup
-                    content={t`Some participants are missing their email. They will be skipped in the cloned newdle`}
+                    content={t`Some participants were not logged in and will be skipped in the cloned newdle.`}
                     trigger={<Icon style={{marginLeft: 5}} name="warning circle" />}
                   />
                 </>

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -21,7 +21,7 @@ import {getCreatedNewdle, isLoggedIn} from '../../selectors';
 import {usePageTitle} from '../../util/hooks';
 import styles from './creation.module.scss';
 
-export default function EditPage() {
+export default function ClonePage() {
   const isUserLoggedIn = useSelector(isLoggedIn);
   const newdle = useSelector(getCreatedNewdle);
   const history = useHistory();
@@ -38,6 +38,8 @@ export default function EditPage() {
   if (!newdle) {
     return <Loader active />;
   }
+
+  const hasParticipantsWithoutEmail = newdle.participants.some(p => p.email === null);
 
   function cloneNewdle() {
     const dayOffset = getDayOffset(newdle.timeslots, newdle.timezone, option, startDate);
@@ -67,7 +69,7 @@ export default function EditPage() {
       <Trans>Keep the timeslots as they are</Trans>
       <Popup
         content={t`Some of the current timeslots are in the past`}
-        trigger={<Icon style={{marginLeft: 5}} name="info circle" />}
+        trigger={<Icon style={{marginLeft: 5}} name="warning circle" />}
       />
     </>
   ) : (
@@ -99,7 +101,17 @@ export default function EditPage() {
           </div>
           <div>
             <label htmlFor="keepParticipants">
-              <Trans>Keep list of participants</Trans>
+              {hasParticipantsWithoutEmail ? (
+                <>
+                  <Trans>Keep list of participants</Trans>
+                  <Popup
+                    content={t`Some participants are missing their email. They will be skipped in the cloned newdle`}
+                    trigger={<Icon style={{marginLeft: 5}} name="warning circle" />}
+                  />
+                </>
+              ) : (
+                <Trans>Keep list of participants</Trans>
+              )}
             </label>
             <Checkbox
               className={styles['advanced-checkbox']}

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -4,6 +4,7 @@ import {useSelector} from 'react-redux';
 import {useHistory} from 'react-router';
 import {Redirect} from 'react-router-dom';
 import {t, Trans} from '@lingui/macro';
+import _ from 'lodash';
 import moment from 'moment';
 import {
   Loader,
@@ -52,7 +53,13 @@ export default function ClonePage() {
           title: keepSettings ? newdle.title : null,
           private: keepSettings ? newdle.private : null,
           notify: keepSettings ? newdle.notify : null,
-          participants: keepParticipants ? newdle.participants : [],
+          participants: keepParticipants
+            ? // Remove participant data (answers, comments) coming from the original newdle.
+              // Participant id is needed for a key in <UserSearch> since email might be missing here.
+              newdle.participants.map(p =>
+                _.pick(p, ['id', 'uid', 'auth_uid', 'signature', 'avatar_url', 'email', 'name'])
+              )
+            : [],
           timeslots: keepTimeslots
             ? moveTimeslots(newdle.timeslots, newdle.timezone, dayOffset)
             : [],

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -1,0 +1,160 @@
+import 'moment-timezone';
+import React, {useState} from 'react';
+import {useSelector} from 'react-redux';
+import {useHistory} from 'react-router';
+import {Redirect} from 'react-router-dom';
+import {t, Trans} from '@lingui/macro';
+import moment from 'moment';
+import {
+  Loader,
+  Button,
+  Container,
+  Input,
+  Checkbox,
+  Radio,
+  Header,
+  Icon,
+  Popup,
+} from 'semantic-ui-react';
+import {serializeDate} from 'src/util/date';
+import {getCreatedNewdle, isLoggedIn} from '../../selectors';
+import {usePageTitle} from '../../util/hooks';
+import styles from './creation.module.scss';
+
+export default function EditPage() {
+  const isUserLoggedIn = useSelector(isLoggedIn);
+  const newdle = useSelector(getCreatedNewdle);
+  const history = useHistory();
+  const [keepParticipants, setKeepParticipants] = useState(true);
+  const [keepTimeslots, setKeepTimeslots] = useState(true);
+  const [option, setOption] = useState('keep');
+  const [startDate, setStartDate] = useState('');
+  usePageTitle('Cloning newdle');
+
+  if (!isUserLoggedIn) {
+    return <Redirect to="/" />;
+  }
+  if (!newdle) {
+    return <Loader active />;
+  }
+
+  function cloneNewdle() {
+    const dayOffset = getDayOffset(newdle.timeslots, newdle.timezone, option, startDate);
+    history.push({
+      pathname: `/new`,
+      state: {
+        participants: keepParticipants ? newdle.participants : [],
+        timeslots: keepTimeslots ? moveTimeslots(newdle.timeslots, newdle.timezone, dayOffset) : [],
+      },
+    });
+  }
+
+  const hasTimeslotsInPast = newdle.timeslots.some(slot =>
+    moment.tz(slot, newdle.timezone).isBefore()
+  );
+  const radioLabel = hasTimeslotsInPast ? (
+    <>
+      <Trans>Keep the timeslots as they are</Trans>
+      <Popup
+        content={t`Some of the current timeslots are in the past`}
+        trigger={<Icon style={{marginLeft: 5}} name="info circle" />}
+      />
+    </>
+  ) : (
+    <Trans>Keep the timeslots as they are</Trans>
+  );
+
+  const canSubmit = option !== 1 || startDate !== '';
+
+  return (
+    <Container text>
+      <div className={styles['advanced-options']} style={{marginTop: 0}}>
+        <div className={styles['headerbar']}>
+          <Header as="h3" className={styles['header']}>
+            <Trans>Cloning options</Trans>
+          </Header>
+        </div>
+        <div className={styles['options']}>
+          <div>
+            <label htmlFor="keepParticipants">
+              <Trans>Keep the list of participants</Trans>
+            </label>
+            <Checkbox
+              className={styles['advanced-checkbox']}
+              id="keepParticipants"
+              toggle
+              checked={keepParticipants}
+              onChange={(_, {checked}) => setKeepParticipants(checked)}
+            />
+          </div>
+          <div>
+            <label htmlFor="keepTimeslots">
+              <Trans>Keep timeslots</Trans>
+            </label>
+            <Checkbox
+              className={styles['advanced-checkbox']}
+              id="keepTimeslots"
+              toggle
+              checked={keepTimeslots}
+              onChange={(_, {checked}) => setKeepTimeslots(checked)}
+            />
+          </div>
+          {keepTimeslots && (
+            <div className={styles['timeslot-options']}>
+              <Radio
+                className={styles['radio']}
+                label={{children: radioLabel}}
+                name="timeslotOptions"
+                checked={option === 'keep'}
+                onChange={() => setOption('keep')}
+              />
+              <Radio
+                className={styles['radio']}
+                label={t`Set the timeslots to start at a specific date`}
+                name="timeslotOptions"
+                checked={option === 'move'}
+                onChange={() => setOption('move')}
+              />
+              {option === 'move' && (
+                <div className={styles['date-input']}>
+                  <span>
+                    <Trans>Starting date:</Trans>
+                  </span>
+                  <Input
+                    type="date"
+                    size="small"
+                    value={startDate}
+                    error={startDate === ''}
+                    onChange={(_, data) => setStartDate(data.value)}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className={styles['create-button']}>
+        <Button color="violet" type="submit" disabled={!canSubmit} onClick={cloneNewdle}>
+          <Trans>Review newdle</Trans> 🍜
+        </Button>
+      </div>
+    </Container>
+  );
+}
+
+function getDayOffset(timeslots, tz, option, startDate) {
+  if (option === 'keep' || timeslots.length === 0) {
+    return 0;
+  } else {
+    const newStart = moment.tz(startDate, tz);
+    const oldStart = moment.tz(timeslots[0], tz);
+    oldStart.set({hour: 0, minute: 0, second: 0, millisecond: 0});
+    return newStart.diff(oldStart, 'days');
+  }
+}
+
+function moveTimeslots(timeslots, tz, dayOffset) {
+  return timeslots.map(slot =>
+    serializeDate(moment.tz(slot, tz).add(dayOffset, 'days'), moment.HTML5_FMT.DATETIME_LOCAL)
+  );
+}

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -135,7 +135,7 @@ export default function EditPage() {
       </div>
       <div className={styles['create-button']}>
         <Button color="violet" type="submit" disabled={!canSubmit} onClick={cloneNewdle}>
-          <Trans>Review newdle</Trans> 🍜
+          <Trans>Review cloned newdle</Trans> 🍜
         </Button>
       </div>
     </Container>

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -28,7 +28,7 @@ export default function EditPage() {
   const [keepParticipants, setKeepParticipants] = useState(true);
   const [keepTimeslots, setKeepTimeslots] = useState(true);
   const [option, setOption] = useState('keep');
-  const [startDate, setStartDate] = useState('');
+  const [startDate, setStartDate] = useState(serializeDate(moment()));
   usePageTitle(t`Cloning newdle`);
 
   if (!isUserLoggedIn) {
@@ -121,6 +121,7 @@ export default function EditPage() {
                     <Trans>Starting date:</Trans>
                   </span>
                   <Input
+                    required
                     type="date"
                     size="small"
                     value={startDate}

--- a/newdle/client/src/components/creation/CreationPage.js
+++ b/newdle/client/src/components/creation/CreationPage.js
@@ -1,6 +1,7 @@
 import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Redirect, useLocation} from 'react-router-dom';
+import {t} from '@lingui/macro';
 import {abortCreation, addParticipants, addTimeslot} from '../../actions';
 import {getStep, isLoggedIn, shouldConfirmAbortCreation} from '../../selectors';
 import {usePageTitle} from '../../util/hooks';
@@ -16,7 +17,7 @@ export default function CreationPage() {
   const step = useSelector(getStep);
   const shouldConfirm = useSelector(shouldConfirmAbortCreation);
   const dispatch = useDispatch();
-  usePageTitle('Create newdle');
+  usePageTitle(t`Create newdle`);
 
   useEffect(() => {
     dispatch(abortCreation());

--- a/newdle/client/src/components/creation/CreationPage.js
+++ b/newdle/client/src/components/creation/CreationPage.js
@@ -2,7 +2,16 @@ import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Redirect, useLocation} from 'react-router-dom';
 import {t} from '@lingui/macro';
-import {abortCreation, addParticipants, addTimeslot} from '../../actions';
+import {
+  abortCreation,
+  addParticipants,
+  addTimeslot,
+  setTitle,
+  setPrivate,
+  setNotification,
+  setDuration,
+  setTimezone,
+} from '../../actions';
 import {getStep, isLoggedIn, shouldConfirmAbortCreation} from '../../selectors';
 import {usePageTitle} from '../../util/hooks';
 import UnloadPrompt from '../UnloadPrompt';
@@ -23,9 +32,23 @@ export default function CreationPage() {
     dispatch(abortCreation());
     // When cloning a newdle we want to prefill the state with
     // the original newdle data
-    if (location.state) {
-      dispatch(addParticipants(location.state.participants));
-      for (const slot of location.state.timeslots) {
+    const cloneData = location.state?.cloneData;
+    if (cloneData) {
+      dispatch(setTimezone(cloneData.timezone));
+      dispatch(setDuration(cloneData.duration));
+      if (cloneData.title !== null) {
+        dispatch(setTitle(cloneData.title));
+      }
+      if (cloneData.private !== null) {
+        dispatch(setPrivate(cloneData.private));
+      }
+      if (cloneData.notify !== null) {
+        dispatch(setNotification(cloneData.notify));
+      }
+      if (cloneData.participants.length) {
+        dispatch(addParticipants(cloneData.participants));
+      }
+      for (const slot of cloneData.timeslots) {
         const [date, time] = slot.split('T');
         dispatch(addTimeslot(date, time));
       }

--- a/newdle/client/src/components/creation/CreationPage.js
+++ b/newdle/client/src/components/creation/CreationPage.js
@@ -40,7 +40,7 @@ export default function CreationPage() {
 
   return (
     <>
-      {step === STEPS.PARTICIPANTS && <ParticipantsStep />}
+      {step === STEPS.PARTICIPANTS && <ParticipantsStep isCloning={!!location.state} />}
       {step === STEPS.TIMESLOTS && <TimeslotsStep />}
       {step === STEPS.FINAL && <FinalStep />}
       <UnloadPrompt router active={shouldConfirm} />

--- a/newdle/client/src/components/creation/CreationSuccessPage.js
+++ b/newdle/client/src/components/creation/CreationSuccessPage.js
@@ -11,7 +11,7 @@ import styles from './CreationSuccessPage.module.scss';
 export default function CreationSuccessPage() {
   const newdle = useSelector(getCreatedNewdle);
   const history = useHistory();
-  usePageTitle('newdle created');
+  usePageTitle(t`Newdle created`);
 
   if (!newdle) {
     return <Redirect to="/new" />;

--- a/newdle/client/src/components/creation/EditPage.js
+++ b/newdle/client/src/components/creation/EditPage.js
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Redirect, Route, Switch, useParams} from 'react-router-dom';
 import {Loader} from 'semantic-ui-react';
-import {abortCreation, fetchNewdle} from '../../actions';
+import {fetchNewdle} from '../../actions';
 import {getCreatedNewdle, isLoggedIn} from '../../selectors';
 import {usePageTitle} from '../../util/hooks';
 import FinalStep from './FinalStep';
@@ -17,17 +17,10 @@ export default function EditPage() {
   usePageTitle('Editing newdle');
 
   useEffect(() => {
-    if (newdleCode) {
-      // TODO: We should re-use the existing newdle data instead. However, abortCreation will clear the state,
-      //  causing an edit -> summary -> edit to become empty if we remove the line below
-      //  Ideally, we should move abortCreation() - state flushing - to happen on mount instead of unmount.
+    if (!newdle && newdleCode) {
       dispatch(fetchNewdle(newdleCode, true));
     }
-
-    return () => {
-      dispatch(abortCreation());
-    };
-  }, [dispatch, newdleCode]);
+  }, [dispatch, newdle, newdleCode]);
 
   if (!isUserLoggedIn) {
     return <Redirect to="/" />;

--- a/newdle/client/src/components/creation/EditPage.js
+++ b/newdle/client/src/components/creation/EditPage.js
@@ -1,6 +1,7 @@
 import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Redirect, Route, Switch, useParams} from 'react-router-dom';
+import {t} from '@lingui/macro';
 import {Loader} from 'semantic-ui-react';
 import {fetchNewdle} from '../../actions';
 import {getCreatedNewdle, isLoggedIn} from '../../selectors';
@@ -14,7 +15,7 @@ export default function EditPage() {
   const isUserLoggedIn = useSelector(isLoggedIn);
   const newdle = useSelector(getCreatedNewdle);
   const dispatch = useDispatch();
-  usePageTitle('Editing newdle');
+  usePageTitle(t`Editing newdle`);
 
   useEffect(() => {
     if (!newdle && newdleCode) {

--- a/newdle/client/src/components/creation/FinalStep.js
+++ b/newdle/client/src/components/creation/FinalStep.js
@@ -42,12 +42,16 @@ export default function FinalStep({isEditing}) {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(isEditing);
 
   async function createNewdle() {
+    // When cloning a newdle, participants that answered via the link
+    // will not have any identifying information that we can use to clone them
+    const participantsWithEmail = participants.filter(p => p.email !== null);
+
     const newdle = await _createNewdle(
       title,
       duration,
       timezone,
       timeslots,
-      participants,
+      participantsWithEmail,
       isPrivate,
       notify
     );

--- a/newdle/client/src/components/creation/ParticipantsStep.js
+++ b/newdle/client/src/components/creation/ParticipantsStep.js
@@ -43,7 +43,7 @@ export default function ParticipantsStep({isEditing, isCloning}) {
           </Message>
         </div>
       )}
-      <UserSearch />
+      <UserSearch isCloning={isCloning} />
       <Container>
         <div className={styles['button-row']}>
           {!isEditing ? (

--- a/newdle/client/src/components/creation/ParticipantsStep.js
+++ b/newdle/client/src/components/creation/ParticipantsStep.js
@@ -3,7 +3,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useHistory} from 'react-router';
 import {t, Trans} from '@lingui/macro';
 import PropTypes from 'prop-types';
-import {Button, Container, Icon} from 'semantic-ui-react';
+import {Button, Container, Icon, Message} from 'semantic-ui-react';
 import {clearParticipantCodes, setStep, updateNewdle} from '../../actions';
 import client from '../../client';
 import {areParticipantsDefined, getCreatedNewdle, getParticipants} from '../../selectors';
@@ -11,7 +11,7 @@ import {STEPS} from './steps';
 import UserSearch from './userSearch';
 import styles from './creation.module.scss';
 
-export default function ParticipantsStep({isEditing}) {
+export default function ParticipantsStep({isEditing, isCloning}) {
   const dispatch = useDispatch();
   const participantsDefined = useSelector(areParticipantsDefined);
   const participants = useSelector(getParticipants);
@@ -31,6 +31,18 @@ export default function ParticipantsStep({isEditing}) {
 
   return (
     <>
+      {isCloning && (
+        <div className={styles['cloning-message']}>
+          <Message info>
+            <p>
+              <Trans>
+                We have prefilled this form with the data you selected. If needed, you can make
+                adjustments and then finalize your newdle in the last step.
+              </Trans>
+            </p>
+          </Message>
+        </div>
+      )}
       <UserSearch />
       <Container>
         <div className={styles['button-row']}>
@@ -57,8 +69,10 @@ export default function ParticipantsStep({isEditing}) {
 
 ParticipantsStep.propTypes = {
   isEditing: PropTypes.bool,
+  isCloning: PropTypes.bool,
 };
 
 ParticipantsStep.defaultProps = {
   isEditing: false,
+  isCloning: false,
 };

--- a/newdle/client/src/components/creation/creation.module.scss
+++ b/newdle/client/src/components/creation/creation.module.scss
@@ -89,6 +89,29 @@
     & > div {
       margin: 0 0.5em 1em 0;
     }
+
+    :global(.ui.radio.checkbox) > label {
+      font-size: 16px;
+      color: #808080;
+    }
+
+    .timeslot-options {
+      margin-left: 0.6em;
+
+      .radio {
+        display: block;
+        margin-bottom: 1em;
+      }
+
+      .date-input {
+        margin-top: 1.5em;
+        margin-left: 2.5em;
+
+        span {
+          margin-right: 1em;
+        }
+      }
+    }
   }
 
   .advanced-checkbox {

--- a/newdle/client/src/components/creation/creation.module.scss
+++ b/newdle/client/src/components/creation/creation.module.scss
@@ -43,6 +43,13 @@
   }
 }
 
+.cloning-message {
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 2em 3em 0 3em;
+}
+
 .create-button {
   display: flex;
   justify-content: center;

--- a/newdle/client/src/components/creation/index.js
+++ b/newdle/client/src/components/creation/index.js
@@ -2,3 +2,4 @@ export {default as CreationPage} from './CreationPage';
 export {default as CreationSuccessPage} from './CreationSuccessPage';
 export {default as CreationHeader} from './CreationHeader';
 export {default as EditPage} from './EditPage';
+export {default as ClonePage} from './ClonePage';

--- a/newdle/client/src/components/creation/userSearch/UserSearch.js
+++ b/newdle/client/src/components/creation/userSearch/UserSearch.js
@@ -111,7 +111,7 @@ export default function UserSearch({isCloning}) {
                       {participant.name}
                       {isCloning && participant.email === null && (
                         <Popup
-                          content={t`This user is missing an email. They will be skipped in the cloned newdle`}
+                          content={t`This user was not logged in and will be skipped in the cloned newdle.`}
                           trigger={
                             <Icon
                               name="warning circle"

--- a/newdle/client/src/components/creation/userSearch/UserSearch.js
+++ b/newdle/client/src/components/creation/userSearch/UserSearch.js
@@ -1,7 +1,8 @@
 import React, {useCallback, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {Trans} from '@lingui/macro';
-import {Button, Container, Icon, Label, List, Modal, Segment} from 'semantic-ui-react';
+import {t, Trans} from '@lingui/macro';
+import PropTypes from 'prop-types';
+import {Button, Container, Icon, Label, List, Modal, Popup, Segment} from 'semantic-ui-react';
 import {addParticipants, removeParticipant} from '../../../actions';
 import client from '../../../client';
 import {getParticipants, getUserInfo} from '../../../selectors';
@@ -24,7 +25,7 @@ async function searchUsers(data, setResults) {
   }
 }
 
-export default function UserSearch() {
+export default function UserSearch({isCloning}) {
   const dispatch = useDispatch();
   const participants = useSelector(getParticipants);
   const user = useSelector(getUserInfo);
@@ -106,7 +107,22 @@ export default function UserSearch() {
                         className={styles['participant-avatar']}
                       />
                     </List.Icon>
-                    <List.Content verticalAlign="middle">{participant.name}</List.Content>
+                    <List.Content verticalAlign="middle">
+                      {participant.name}
+                      {isCloning && participant.email === null && (
+                        <Popup
+                          content={t`This user is missing an email. They will be skipped in the cloned newdle`}
+                          trigger={
+                            <Icon
+                              name="warning circle"
+                              size="large"
+                              color="orange"
+                              style={{marginLeft: 7}}
+                            />
+                          }
+                        />
+                      )}
+                    </List.Content>
                   </List.Item>
                 ))}
             </List>
@@ -165,3 +181,11 @@ export default function UserSearch() {
     </>
   );
 }
+
+UserSearch.propTypes = {
+  isCloning: PropTypes.bool,
+};
+
+UserSearch.defaultProps = {
+  isCloning: false,
+};

--- a/newdle/client/src/components/summary/SummaryHeader.js
+++ b/newdle/client/src/components/summary/SummaryHeader.js
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
-import {abortCreation, clearNewdle, fetchNewdle} from '../../actions';
+import {clearNewdle, fetchNewdle} from '../../actions';
 import {getNewdle} from '../../selectors';
 import NewdleTitle from '../NewdleTitle';
 
@@ -15,7 +15,6 @@ export default function SummaryHeader({match}) {
 
     return () => {
       dispatch(clearNewdle());
-      dispatch(abortCreation());
     };
   }, [code, dispatch]);
 

--- a/newdle/client/src/components/summary/SummaryPage.js
+++ b/newdle/client/src/components/summary/SummaryPage.js
@@ -87,6 +87,7 @@ export default function SummaryPage() {
 
   const mailSent = sendMailResponse !== null;
   const editUrl = `/newdle/${newdle.code}/edit`;
+  const cloneUrl = `/newdle/${newdle.code}/clone`;
 
   const createEvent = async (event, {value}) => {
     const resp = await _createEvent(newdle.code);
@@ -211,6 +212,9 @@ export default function SummaryPage() {
           {isCreator && (
             <div className={styles['button-row']}>
               {gridViewActive && actions}
+              <Button color="blue" as={Link} to={cloneUrl}>
+                <Trans>Clone newdle</Trans>
+              </Button>
               <Dropdown text={t`Export answers`} button direction="right" color="teal" as={Button}>
                 <Dropdown.Menu>
                   <Dropdown.Item
@@ -225,11 +229,7 @@ export default function SummaryPage() {
                   />
                 </Dropdown.Menu>
               </Dropdown>
-              <Button
-                color="red"
-                className={styles['delete-button']}
-                onClick={() => setDeletionModalOpen(true)}
-              >
+              <Button color="red" onClick={() => setDeletionModalOpen(true)}>
                 <Trans>Delete newdle</Trans>
               </Button>
             </div>
@@ -297,6 +297,7 @@ export default function SummaryPage() {
                   <Dropdown.Item as={Link} text={t`Participants`} to={`${editUrl}/participants`} />
                   <Dropdown.Item as={Link} text={t`Timeslots`} to={editUrl} />
                   <Dropdown.Item as={Link} text={t`Options`} to={`${editUrl}/options`} />
+                  <Dropdown.Item as={Link} text={t`Clone newdle`} to={cloneUrl} />
                   <Dropdown.Item
                     text={t`Delete newdle`}
                     onClick={() => setDeletionModalOpen(true)}

--- a/newdle/client/src/components/summary/SummaryPage.js
+++ b/newdle/client/src/components/summary/SummaryPage.js
@@ -53,7 +53,7 @@ export default function SummaryPage() {
   const [_setFinalDate, submitting] = client.useBackendLazy(client.setFinalDate);
   const [_createEvent] = client.useBackendLazy(client.createEvent);
   const [config, loading] = client.useBackend(() => client.getConfig(), []);
-  usePageTitle(newdle && `Summary: ${newdle.title}`, true);
+  usePageTitle(newdle && t`Summary: ${newdle.title}`, true);
 
   const update = async () => {
     const updatedNewdle = await _setFinalDate(newdle.code, finalDate);

--- a/newdle/client/src/components/summary/SummaryPage.js
+++ b/newdle/client/src/components/summary/SummaryPage.js
@@ -212,7 +212,7 @@ export default function SummaryPage() {
           {isCreator && (
             <div className={styles['button-row']}>
               {gridViewActive && actions}
-              <Button color="blue" as={Link} to={cloneUrl}>
+              <Button color="teal" as={Link} to={cloneUrl}>
                 <Trans>Clone newdle</Trans>
               </Button>
               <Dropdown text={t`Export answers`} button direction="right" color="teal" as={Button}>

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -104,11 +104,11 @@ msgstr ""
 msgid "Clone newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:32
+#: src/components/creation/ClonePage.js:33
 msgid "Cloning newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:74
+#: src/components/creation/ClonePage.js:87
 msgid "Cloning options"
 msgstr ""
 
@@ -220,21 +220,25 @@ msgstr "¿Cómo funciona?"
 msgid "It is not possible to answer this newdle anymore."
 msgstr ""
 
+#: src/components/creation/ClonePage.js:105
+msgid "Keep list of participants"
+msgstr ""
+
 #: src/components/creation/FinalStep.js:125
 msgid "Keep list of participants private"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:80
-msgid "Keep the list of participants"
-msgstr ""
-
-#: src/components/creation/ClonePage.js:57
-#: src/components/creation/ClonePage.js:64
+#: src/components/creation/ClonePage.js:70
+#: src/components/creation/ClonePage.js:77
 msgid "Keep the timeslots as they are"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:92
+#: src/components/creation/ClonePage.js:117
 msgid "Keep timeslots"
+msgstr ""
+
+#: src/components/creation/ClonePage.js:93
+msgid "Keep title and settings"
 msgstr ""
 
 #: src/components/summary/DeleteModal.js:74
@@ -360,7 +364,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:139
+#: src/components/creation/ClonePage.js:164
 msgid "Review cloned newdle"
 msgstr ""
 
@@ -384,7 +388,7 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
-#: src/components/creation/ClonePage.js:113
+#: src/components/creation/ClonePage.js:138
 msgid "Set the timeslots to start at a specific date"
 msgstr ""
 
@@ -396,7 +400,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:59
+#: src/components/creation/ClonePage.js:72
 msgid "Some of the current timeslots are in the past"
 msgstr ""
 
@@ -409,7 +413,7 @@ msgstr ""
 msgid "Something went wrong when notifying participants:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:121
+#: src/components/creation/ClonePage.js:146
 msgid "Starting date:"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -71,7 +71,7 @@ msgstr ""
 
 #: src/components/creation/userSearch/UserSearch.js:159
 #: src/components/login/LoginPrompt.js:45
-#: src/components/summary/SummaryPage.js:185
+#: src/components/summary/SummaryPage.js:186
 msgid "Cancel"
 msgstr ""
 
@@ -99,10 +99,19 @@ msgstr "Elige a los participantes"
 msgid "Click to add time slots"
 msgstr ""
 
+#: src/components/summary/SummaryPage.js:216
+#: src/components/summary/SummaryPage.js:300
+msgid "Clone newdle"
+msgstr ""
+
+#: src/components/creation/ClonePage.js:74
+msgid "Cloning options"
+msgstr ""
+
 #: src/components/creation/ParticipantsStep.js:49
 #: src/components/creation/timeslots/TimeslotsStep.js:103
 #: src/components/creation/userSearch/UserSearch.js:156
-#: src/components/summary/SummaryPage.js:182
+#: src/components/summary/SummaryPage.js:183
 msgid "Confirm"
 msgstr ""
 
@@ -124,7 +133,7 @@ msgstr ""
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:115
+#: src/components/summary/SummaryPage.js:116
 msgid "Create event"
 msgstr ""
 
@@ -138,7 +147,7 @@ msgstr ""
 
 #: src/components/summary/DeleteModal.js:96
 #: src/components/summary/SummaryPage.js:233
-#: src/components/summary/SummaryPage.js:301
+#: src/components/summary/SummaryPage.js:302
 msgid "Delete newdle"
 msgstr ""
 
@@ -158,8 +167,8 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:110
-#: src/components/summary/SummaryPage.js:155
+#: src/components/summary/SummaryPage.js:111
+#: src/components/summary/SummaryPage.js:156
 msgid "E-mail participants"
 msgstr ""
 
@@ -175,7 +184,7 @@ msgstr ""
 msgid "Error occurred"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:214
+#: src/components/summary/SummaryPage.js:218
 msgid "Export answers"
 msgstr ""
 
@@ -201,6 +210,19 @@ msgstr ""
 
 #: src/components/creation/FinalStep.js:125
 msgid "Keep list of participants private"
+msgstr ""
+
+#: src/components/creation/ClonePage.js:80
+msgid "Keep the list of participants"
+msgstr ""
+
+#: src/components/creation/ClonePage.js:57
+#: src/components/creation/ClonePage.js:64
+msgid "Keep the timeslots as they are"
+msgstr ""
+
+#: src/components/creation/ClonePage.js:92
+msgid "Keep timeslots"
 msgstr ""
 
 #: src/components/summary/DeleteModal.js:74
@@ -284,7 +306,7 @@ msgstr ""
 msgid "Nobody has voted yet."
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:143
+#: src/components/summary/SummaryPage.js:144
 msgid "Note that some of your participants did not provide an email address and thus could not be notified!"
 msgstr ""
 
@@ -317,6 +339,10 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
+#: src/components/creation/ClonePage.js:138
+msgid "Review newdle"
+msgstr ""
+
 #: src/components/creation/userSearch/UserSearchForm.js:48
 msgid "Search"
 msgstr ""
@@ -337,6 +363,10 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
+#: src/components/creation/ClonePage.js:113
+msgid "Set the timeslots to start at a specific date"
+msgstr ""
+
 #: src/components/NewdleTitle.js:120
 msgid "Shareable link"
 msgstr ""
@@ -345,20 +375,28 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
+#: src/components/creation/ClonePage.js:59
+msgid "Some of the current timeslots are in the past"
+msgstr ""
+
 #: src/components/summary/DeleteModal.js:83
-#: src/components/summary/SummaryPage.js:164
+#: src/components/summary/SummaryPage.js:165
 msgid "Some of your participants do not have e-mail addresses and will not be contacted:"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:129
+#: src/components/summary/SummaryPage.js:130
 msgid "Something went wrong when notifying participants:"
+msgstr ""
+
+#: src/components/creation/ClonePage.js:121
+msgid "Starting date:"
 msgstr ""
 
 #: src/components/summary/SummaryPage.js:266
 msgid "The following participants have not voted yet:"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:139
+#: src/components/summary/SummaryPage.js:140
 msgid "The participants have been notified of the final date."
 msgstr ""
 
@@ -487,7 +525,7 @@ msgstr ""
 msgid "{0, plural, =0 {No participants registered} one {# participant registered} other {# participants registered}}"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:172
+#: src/components/summary/SummaryPage.js:173
 msgid "{0, plural, one {# participant will be e-mailed:} other {# participants will be e-mailed:}}"
 msgstr ""
 
@@ -504,7 +542,7 @@ msgstr ""
 msgid "{0, plural, one {{1} out of # participant answered} other {{2} out of # participants answered}}"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:191
+#: src/components/summary/SummaryPage.js:192
 msgid "{0} will take place on:"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -25,15 +25,15 @@ msgstr "<0>newdle</0> guardará las respuestas"
 msgid "Accept all options where I'm available"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:63
+#: src/components/creation/userSearch/UserSearch.js:64
 msgid "Add myself"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:145
+#: src/components/creation/userSearch/UserSearch.js:146
 msgid "Add new participants"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:76
+#: src/components/creation/userSearch/UserSearch.js:77
 msgid "Add participant"
 msgstr ""
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:175
+#: src/components/creation/userSearch/UserSearch.js:176
 #: src/components/login/LoginPrompt.js:45
 #: src/components/summary/SummaryPage.js:186
 msgid "Cancel"
@@ -104,17 +104,17 @@ msgstr ""
 msgid "Clone newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:33
+#: src/components/creation/ClonePage.js:34
 msgid "Cloning newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:86
+#: src/components/creation/ClonePage.js:93
 msgid "Cloning options"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:61
+#: src/components/creation/ParticipantsStep.js:63
 #: src/components/creation/timeslots/TimeslotsStep.js:103
-#: src/components/creation/userSearch/UserSearch.js:172
+#: src/components/creation/userSearch/UserSearch.js:173
 #: src/components/summary/SummaryPage.js:183
 msgid "Confirm"
 msgstr ""
@@ -220,8 +220,8 @@ msgstr "¿Cómo funciona?"
 msgid "It is not possible to answer this newdle anymore."
 msgstr ""
 
-#: src/components/creation/ClonePage.js:106
 #: src/components/creation/ClonePage.js:113
+#: src/components/creation/ClonePage.js:120
 msgid "Keep list of participants"
 msgstr ""
 
@@ -229,16 +229,16 @@ msgstr ""
 msgid "Keep list of participants private"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:69
 #: src/components/creation/ClonePage.js:76
+#: src/components/creation/ClonePage.js:83
 msgid "Keep the timeslots as they are"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:126
+#: src/components/creation/ClonePage.js:133
 msgid "Keep timeslots"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:92
+#: src/components/creation/ClonePage.js:99
 msgid "Keep title and settings"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Newdles I'm participating in"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:56
+#: src/components/creation/ParticipantsStep.js:58
 msgid "Next"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr ""
 msgid "No options chosen"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:131
+#: src/components/creation/userSearch/UserSearch.js:132
 msgid "No participants selected"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:173
+#: src/components/creation/ClonePage.js:180
 msgid "Review cloned newdle"
 msgstr ""
 
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
-#: src/components/creation/ClonePage.js:147
+#: src/components/creation/ClonePage.js:154
 msgid "Set the timeslots to start at a specific date"
 msgstr ""
 
@@ -397,11 +397,11 @@ msgstr ""
 msgid "Shareable link"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:56
+#: src/components/creation/ParticipantsStep.js:58
 msgid "Skip"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:71
+#: src/components/creation/ClonePage.js:78
 msgid "Some of the current timeslots are in the past"
 msgstr ""
 
@@ -410,7 +410,7 @@ msgstr ""
 msgid "Some of your participants do not have e-mail addresses and will not be contacted:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:108
+#: src/components/creation/ClonePage.js:115
 msgid "Some participants are missing their email. They will be skipped in the cloned newdle"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Something went wrong when notifying participants:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:155
+#: src/components/creation/ClonePage.js:162
 msgid "Starting date:"
 msgstr ""
 
@@ -461,7 +461,7 @@ msgstr ""
 msgid "This page is personal and its URL should not be shared. Please use the shareable link above to share the newdle with others."
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:114
+#: src/components/creation/userSearch/UserSearch.js:115
 msgid "This user is missing an email. They will be skipped in the cloned newdle"
 msgstr ""
 
@@ -489,7 +489,7 @@ msgstr ""
 msgid "We are almost there!"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:38
+#: src/components/creation/ParticipantsStep.js:40
 msgid "We have prefilled this form with the data you selected. If needed, you can make adjustments and then finalize your newdle in the last step."
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -25,15 +25,15 @@ msgstr "<0>newdle</0> guardará las respuestas"
 msgid "Accept all options where I'm available"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:64
+#: src/components/creation/userSearch/UserSearch.js:63
 msgid "Add myself"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:146
+#: src/components/creation/userSearch/UserSearch.js:145
 msgid "Add new participants"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:77
+#: src/components/creation/userSearch/UserSearch.js:76
 msgid "Add participant"
 msgstr ""
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:176
+#: src/components/creation/userSearch/UserSearch.js:175
 #: src/components/login/LoginPrompt.js:45
 #: src/components/summary/SummaryPage.js:186
 msgid "Cancel"
@@ -112,9 +112,9 @@ msgstr ""
 msgid "Cloning options"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:63
+#: src/components/creation/ParticipantsStep.js:61
 #: src/components/creation/timeslots/TimeslotsStep.js:103
-#: src/components/creation/userSearch/UserSearch.js:173
+#: src/components/creation/userSearch/UserSearch.js:172
 #: src/components/summary/SummaryPage.js:183
 msgid "Confirm"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Newdles I'm participating in"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:58
+#: src/components/creation/ParticipantsStep.js:56
 msgid "Next"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr ""
 msgid "No options chosen"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:132
+#: src/components/creation/userSearch/UserSearch.js:131
 msgid "No participants selected"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Shareable link"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:58
+#: src/components/creation/ParticipantsStep.js:56
 msgid "Skip"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgid "Some of your participants do not have e-mail addresses and will not be co
 msgstr ""
 
 #: src/components/creation/ClonePage.js:115
-msgid "Some participants are missing their email. They will be skipped in the cloned newdle"
+msgid "Some participants were not logged in and will be skipped in the cloned newdle."
 msgstr ""
 
 #: src/components/summary/SummaryPage.js:130
@@ -461,8 +461,8 @@ msgstr ""
 msgid "This page is personal and its URL should not be shared. Please use the shareable link above to share the newdle with others."
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:115
-msgid "This user is missing an email. They will be skipped in the cloned newdle"
+#: src/components/creation/userSearch/UserSearch.js:114
+msgid "This user was not logged in and will be skipped in the cloned newdle."
 msgstr ""
 
 #: src/components/summary/SummaryPage.js:298
@@ -489,7 +489,7 @@ msgstr ""
 msgid "We are almost there!"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:40
+#: src/components/creation/ParticipantsStep.js:38
 msgid "We have prefilled this form with the data you selected. If needed, you can make adjustments and then finalize your newdle in the last step."
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -99,13 +99,10 @@ msgstr "Elige a los participantes"
 msgid "Click to add time slots"
 msgstr ""
 
+#: src/components/creation/ClonePage.js:34
 #: src/components/summary/SummaryPage.js:216
 #: src/components/summary/SummaryPage.js:300
 msgid "Clone newdle"
-msgstr ""
-
-#: src/components/creation/ClonePage.js:34
-msgid "Cloning newdle"
 msgstr ""
 
 #: src/components/creation/ClonePage.js:93

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -104,6 +104,10 @@ msgstr ""
 msgid "Clone newdle"
 msgstr ""
 
+#: src/components/creation/ClonePage.js:32
+msgid "Cloning newdle"
+msgstr ""
+
 #: src/components/creation/ClonePage.js:74
 msgid "Cloning options"
 msgstr ""
@@ -135,6 +139,10 @@ msgstr ""
 
 #: src/components/summary/SummaryPage.js:116
 msgid "Create event"
+msgstr ""
+
+#: src/components/creation/CreationPage.js:20
+msgid "Create newdle"
 msgstr ""
 
 #: src/components/MyNewdles.js:46
@@ -174,6 +182,10 @@ msgstr ""
 
 #: src/components/summary/SummaryPage.js:288
 msgid "Edit"
+msgstr ""
+
+#: src/components/creation/EditPage.js:18
+msgid "Editing newdle"
 msgstr ""
 
 #: src/components/creation/userSearch/UserSearchForm.js:40
@@ -266,6 +278,7 @@ msgstr ""
 msgid "Missing search criteria"
 msgstr ""
 
+#: src/components/MyNewdles.js:17
 #: src/components/UserMenu.js:39
 msgid "My newdles"
 msgstr ""
@@ -274,8 +287,16 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#: src/components/creation/CreationSuccessPage.js:14
+msgid "Newdle created"
+msgstr ""
+
 #: src/components/UserMenu.js:48
 msgid "Newdles I'm in"
+msgstr ""
+
+#: src/components/NewdlesParticipating.js:14
+msgid "Newdles I'm participating in"
 msgstr ""
 
 #: src/components/creation/ParticipantsStep.js:44
@@ -390,6 +411,10 @@ msgstr ""
 
 #: src/components/creation/ClonePage.js:121
 msgid "Starting date:"
+msgstr ""
+
+#: src/components/summary/SummaryPage.js:56
+msgid "Summary: {0}"
 msgstr ""
 
 #: src/components/summary/SummaryPage.js:266

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -25,19 +25,19 @@ msgstr "<0>newdle</0> guardará las respuestas"
 msgid "Accept all options where I'm available"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:62
+#: src/components/creation/userSearch/UserSearch.js:63
 msgid "Add myself"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:129
+#: src/components/creation/userSearch/UserSearch.js:145
 msgid "Add new participants"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:75
+#: src/components/creation/userSearch/UserSearch.js:76
 msgid "Add participant"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:117
+#: src/components/creation/FinalStep.js:121
 msgid "Advanced options"
 msgstr ""
 
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Are you sure you want to leave this page without saving?"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:93
+#: src/components/creation/FinalStep.js:97
 msgid "Attention"
 msgstr ""
 
@@ -69,17 +69,17 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:159
+#: src/components/creation/userSearch/UserSearch.js:175
 #: src/components/login/LoginPrompt.js:45
 #: src/components/summary/SummaryPage.js:186
 msgid "Cancel"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:178
+#: src/components/creation/FinalStep.js:182
 msgid "Change participants"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:187
+#: src/components/creation/FinalStep.js:191
 msgid "Change time slots"
 msgstr ""
 
@@ -108,18 +108,18 @@ msgstr ""
 msgid "Cloning newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:84
+#: src/components/creation/ClonePage.js:86
 msgid "Cloning options"
 msgstr ""
 
 #: src/components/creation/ParticipantsStep.js:61
 #: src/components/creation/timeslots/TimeslotsStep.js:103
-#: src/components/creation/userSearch/UserSearch.js:156
+#: src/components/creation/userSearch/UserSearch.js:172
 #: src/components/summary/SummaryPage.js:183
 msgid "Confirm"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:165
+#: src/components/creation/FinalStep.js:169
 msgid "Confirm changes"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgstr ""
 msgid "Create your first newdle!"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:162
+#: src/components/creation/FinalStep.js:166
 msgid "Create your newdle!"
 msgstr ""
 
@@ -220,24 +220,25 @@ msgstr "¿Cómo funciona?"
 msgid "It is not possible to answer this newdle anymore."
 msgstr ""
 
-#: src/components/creation/ClonePage.js:102
+#: src/components/creation/ClonePage.js:106
+#: src/components/creation/ClonePage.js:113
 msgid "Keep list of participants"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:125
+#: src/components/creation/FinalStep.js:129
 msgid "Keep list of participants private"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:67
-#: src/components/creation/ClonePage.js:74
+#: src/components/creation/ClonePage.js:69
+#: src/components/creation/ClonePage.js:76
 msgid "Keep the timeslots as they are"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:114
+#: src/components/creation/ClonePage.js:126
 msgid "Keep timeslots"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:90
+#: src/components/creation/ClonePage.js:92
 msgid "Keep title and settings"
 msgstr ""
 
@@ -319,7 +320,7 @@ msgstr ""
 msgid "No options chosen"
 msgstr ""
 
-#: src/components/creation/userSearch/UserSearch.js:115
+#: src/components/creation/userSearch/UserSearch.js:131
 msgid "No participants selected"
 msgstr ""
 
@@ -335,11 +336,11 @@ msgstr ""
 msgid "Note that some of your participants did not provide an email address and thus could not be notified!"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:138
+#: src/components/creation/FinalStep.js:142
 msgid "Notify me about new answers"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:103
+#: src/components/creation/FinalStep.js:107
 msgid "Once the newdle is created, you will be shown a link which you need to send to anyone you wish to invite."
 msgstr ""
 
@@ -352,7 +353,7 @@ msgstr ""
 msgid "Participants"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:79
+#: src/components/creation/FinalStep.js:83
 msgid "Please enter a title for your event..."
 msgstr ""
 
@@ -364,7 +365,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:161
+#: src/components/creation/ClonePage.js:173
 msgid "Review cloned newdle"
 msgstr ""
 
@@ -388,7 +389,7 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
-#: src/components/creation/ClonePage.js:135
+#: src/components/creation/ClonePage.js:147
 msgid "Set the timeslots to start at a specific date"
 msgstr ""
 
@@ -400,7 +401,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:69
+#: src/components/creation/ClonePage.js:71
 msgid "Some of the current timeslots are in the past"
 msgstr ""
 
@@ -409,11 +410,15 @@ msgstr ""
 msgid "Some of your participants do not have e-mail addresses and will not be contacted:"
 msgstr ""
 
+#: src/components/creation/ClonePage.js:108
+msgid "Some participants are missing their email. They will be skipped in the cloned newdle"
+msgstr ""
+
 #: src/components/summary/SummaryPage.js:130
 msgid "Something went wrong when notifying participants:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:143
+#: src/components/creation/ClonePage.js:155
 msgid "Starting date:"
 msgstr ""
 
@@ -454,6 +459,10 @@ msgstr ""
 
 #: src/components/answer/AnswerPage.js:320
 msgid "This page is personal and its URL should not be shared. Please use the shareable link above to share the newdle with others."
+msgstr ""
+
+#: src/components/creation/userSearch/UserSearch.js:114
+msgid "This user is missing an email. They will be skipped in the cloned newdle"
 msgstr ""
 
 #: src/components/summary/SummaryPage.js:298
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Your newdle was created. You can now send the following to everyone you would like to invite:"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:97
+#: src/components/creation/FinalStep.js:101
 msgid "Your participants will receive an e-mail asking them to register to their preference. Once the newdle is created, you will be shown a link you can share with anyone else you wish to invite."
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Cloning newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:87
+#: src/components/creation/ClonePage.js:84
 msgid "Cloning options"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Create event"
 msgstr ""
 
-#: src/components/creation/CreationPage.js:20
+#: src/components/creation/CreationPage.js:29
 msgid "Create newdle"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr "¿Cómo funciona?"
 msgid "It is not possible to answer this newdle anymore."
 msgstr ""
 
-#: src/components/creation/ClonePage.js:105
+#: src/components/creation/ClonePage.js:102
 msgid "Keep list of participants"
 msgstr ""
 
@@ -228,16 +228,16 @@ msgstr ""
 msgid "Keep list of participants private"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:70
-#: src/components/creation/ClonePage.js:77
+#: src/components/creation/ClonePage.js:67
+#: src/components/creation/ClonePage.js:74
 msgid "Keep the timeslots as they are"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:117
+#: src/components/creation/ClonePage.js:114
 msgid "Keep timeslots"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:93
+#: src/components/creation/ClonePage.js:90
 msgid "Keep title and settings"
 msgstr ""
 
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:164
+#: src/components/creation/ClonePage.js:161
 msgid "Review cloned newdle"
 msgstr ""
 
@@ -388,7 +388,7 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
-#: src/components/creation/ClonePage.js:138
+#: src/components/creation/ClonePage.js:135
 msgid "Set the timeslots to start at a specific date"
 msgstr ""
 
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:72
+#: src/components/creation/ClonePage.js:69
 msgid "Some of the current timeslots are in the past"
 msgstr ""
 
@@ -413,7 +413,7 @@ msgstr ""
 msgid "Something went wrong when notifying participants:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:146
+#: src/components/creation/ClonePage.js:143
 msgid "Starting date:"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:138
+#: src/components/creation/ClonePage.js:139
 msgid "Review cloned newdle"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Cloning options"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:49
+#: src/components/creation/ParticipantsStep.js:61
 #: src/components/creation/timeslots/TimeslotsStep.js:103
 #: src/components/creation/userSearch/UserSearch.js:156
 #: src/components/summary/SummaryPage.js:183
@@ -299,7 +299,7 @@ msgstr ""
 msgid "Newdles I'm participating in"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:44
+#: src/components/creation/ParticipantsStep.js:56
 msgid "Next"
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid "Please log in again to confirm your identity"
 msgstr ""
 
 #: src/components/creation/ClonePage.js:138
-msgid "Review newdle"
+msgid "Review cloned newdle"
 msgstr ""
 
 #: src/components/creation/userSearch/UserSearchForm.js:48
@@ -392,7 +392,7 @@ msgstr ""
 msgid "Shareable link"
 msgstr ""
 
-#: src/components/creation/ParticipantsStep.js:44
+#: src/components/creation/ParticipantsStep.js:56
 msgid "Skip"
 msgstr ""
 
@@ -474,6 +474,10 @@ msgstr ""
 
 #: src/components/creation/CreationHeader.js:24
 msgid "We are almost there!"
+msgstr ""
+
+#: src/components/creation/ParticipantsStep.js:38
+msgid "We have prefilled this form with the data you selected. If needed, you can make adjustments and then finalize your newdle in the last step."
 msgstr ""
 
 #: src/components/home/HomeHeader.js:8


### PR DESCRIPTION
Adds a simple form where you can choose to keep participants and/or timeslots. You can also move the timeslots to some other date, that is, the timeslots will start on the selected date. This form then takes you to a prefilled newdle creation page where you can proceed as usual when creating a newdle.

![image](https://user-images.githubusercontent.com/8739637/165106553-a4b73906-6a6d-4e71-a969-9bb1a290d85c.png)
![image](https://user-images.githubusercontent.com/8739637/165106478-f6d03576-23c0-469e-9625-12d9cc9c28ee.png)
![image](https://user-images.githubusercontent.com/8739637/165106645-0391fb25-017b-4088-bc19-f12db948843d.png)
