### PR TITLE
Take newdle duration from answerSelectors

### DIFF
--- a/newdle/client/src/components/GridCommon.js
+++ b/newdle/client/src/components/GridCommon.js
@@ -4,7 +4,7 @@ import {Trans} from '@lingui/macro';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import {Icon, Table, Radio, Popup} from 'semantic-ui-react';
-import {getNewdleDuration, getNewdleTimezone} from '../selectors';
+import {getNewdleDuration, getNewdleTimezone} from '../answerSelectors';
 import {serializeDate, toMoment} from '../util/date';
 import AvailabilityRing from './AvailabilityRing';
 import styles from './GridCommon.module.scss';


### PR DESCRIPTION
Fixes a bug where the grid view in private newdles showed incorrect time ranges:

![image](https://user-images.githubusercontent.com/8739637/165466485-3296b045-d959-49e2-b46a-a1b05434ae9d.png)
