### PR TITLE
Add option so that each slot can only be selected once

### DIFF
--- a/newdle/answers.py
+++ b/newdle/answers.py
@@ -1,0 +1,58 @@
+from collections import Counter
+
+from newdle.core.util import format_dt
+from newdle.models import Availability
+
+from .core.webargs import abort
+
+
+def validate_answers(newdle, participant, answers):
+    invalid = answers.keys() - set(newdle.timeslots)
+    if invalid:
+        abort(
+            422,
+            messages={
+                'answers': {
+                    format_dt(key): {'key': ['Invalid timeslot']} for key in invalid
+                }
+            },
+        )
+
+    if newdle.limited_slots:
+        # 'ifneedbe' is not allowed for newdles with limited slots
+        if Availability.ifneedbe in answers.values():
+            abort(
+                422,
+                messages={
+                    'answers': [
+                        "'if-need-be' is not allowed in newdles with limited slots"
+                    ]
+                },
+            )
+
+        # Must have at most one 'available'
+        counts = Counter(answers.values())
+        if counts[Availability.available] > 1:
+            abort(
+                422,
+                messages={'answers': ["At most one 'available' may be present"]},
+            )
+
+        # The slot must not be already taken
+        timeslot = next(
+            (
+                slot
+                for slot, availability in answers.items()
+                if availability == Availability.available
+            ),
+            None,
+        )
+        if timeslot is not None and any(
+            p.answers.get(timeslot) == Availability.available
+            for p in newdle.participants
+            if p.code != participant.code
+        ):
+            return {
+                'code': 409,
+                'messages': {'answers': ['The selected timeslot is already taken']},
+            }

--- a/newdle/answers.py
+++ b/newdle/answers.py
@@ -3,40 +3,38 @@ from collections import Counter
 from newdle.core.util import format_dt
 from newdle.models import Availability
 
-from .core.webargs import abort
-
 
 def validate_answers(newdle, participant, answers):
     invalid = answers.keys() - set(newdle.timeslots)
     if invalid:
-        abort(
-            422,
-            messages={
+        return {
+            'code': 422,
+            'messages': {
                 'answers': {
                     format_dt(key): {'key': ['Invalid timeslot']} for key in invalid
                 }
             },
-        )
+        }
 
     if newdle.limited_slots:
         # 'ifneedbe' is not allowed for newdles with limited slots
         if Availability.ifneedbe in answers.values():
-            abort(
-                422,
-                messages={
+            return {
+                'code': 422,
+                'messages': {
                     'answers': [
                         "'if-need-be' is not allowed in newdles with limited slots"
                     ]
                 },
-            )
+            }
 
         # Must have at most one 'available'
         counts = Counter(answers.values())
         if counts[Availability.available] > 1:
-            abort(
-                422,
-                messages={'answers': ["At most one 'available' may be present"]},
-            )
+            return {
+                'code': 422,
+                'messages': {'answers': ["At most one 'available' may be present"]},
+            }
 
         # The slot must not be already taken
         timeslot = next(

--- a/newdle/api.py
+++ b/newdle/api.py
@@ -30,7 +30,6 @@ from .core.util import (
     DATE_FORMAT,
     avatar_info_from_payload,
     change_dt_timezone,
-    format_dt,
     range_union,
     render_user_avatar,
 )

--- a/newdle/api.py
+++ b/newdle/api.py
@@ -473,7 +473,8 @@ def update_participant(args, code, participant_code):
     if 'answers' in args:
         # We can't validate this in webargs, since we don't have access
         # to the Newdle inside the schema...
-        validate_answers(newdle, participant, args['answers'])
+        if err := validate_answers(newdle, participant, args['answers']):
+            abort(err['code'], messages=err['messages'])
 
     is_update = bool(participant.answers)
     for key, value in args.items():

--- a/newdle/client/src/actions.js
+++ b/newdle/client/src/actions.js
@@ -23,6 +23,7 @@ export const ADD_TIMESLOT = 'Add new timeslot';
 export const REMOVE_TIMESLOT = 'Remove a timeslot';
 export const SET_TITLE = 'Set title for Newdle';
 export const SET_PRIVATE = 'Keep list of participants private';
+export const SET_LIMITED_SLOTS = 'One slot per participant';
 export const SET_NOTIFICATION = 'Notify creator about new answers';
 export const SET_TIMEZONE = 'Set the meeting timezone';
 export const NEWDLE_RECEIVED = 'Received newdle data';
@@ -153,6 +154,10 @@ export function setPrivate(isPrivate) {
   return {type: SET_PRIVATE, private: isPrivate};
 }
 
+export function setLimitedSlots(limitedSlots) {
+  return {type: SET_LIMITED_SLOTS, limitedSlots};
+}
+
 export function setNotification(notify) {
   return {type: SET_NOTIFICATION, notify};
 }
@@ -200,7 +205,10 @@ export function chooseAllAvailable(enabled) {
 export function setAnswer(timeslot, answer) {
   return async (dispatch, getStore) => {
     const state = getStore();
-    if (isAllAvailableSelectedExplicitly(state)) {
+    if (state.answer.newdle.limited_slots) {
+      // Clear previous answer
+      dispatch({type: REPLACE_ANSWERS, answers: {}});
+    } else if (isAllAvailableSelectedExplicitly(state)) {
       const answers = getAnswers(state);
       dispatch({type: REPLACE_ANSWERS, answers});
     }

--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -12,9 +12,23 @@ export const isParticipantUnknown = state =>
   !state.answer.participant || state.answer.participant.auth_uid === null;
 export const getNewdleDuration = state => state.answer.newdle && state.answer.newdle.duration;
 export const getNewdleTimezone = state => state.answer.newdle && state.answer.newdle.timezone;
+export const hasLimitedSlots = state => state.answer.newdle && state.answer.newdle.limited_slots;
 export const getNewdleTimeslots = state =>
   (state.answer.newdle && state.answer.newdle.timeslots) || [];
 export const getNumberOfTimeslots = createSelector(getNewdleTimeslots, slots => slots.length);
+export const getAvailableTimeslots = createSelector(
+  hasLimitedSlots,
+  getNewdleTimeslots,
+  state => (state.answer.newdle && state.answer.newdle.available_timeslots) || [],
+  getParticipantAnswers,
+  (limitedSlots, timeslots, availableTimeslots, answers) => {
+    if (!limitedSlots) {
+      return timeslots;
+    }
+    const available = Object.keys(answers).filter(slot => answers[slot] === 'available');
+    return availableTimeslots.concat(available);
+  }
+);
 export const getUserTimezone = state => state.answer.userTimezone;
 export const getLocalNewdleTimeslots = createSelector(
   getNewdleTimeslots,

--- a/newdle/client/src/components/GridCommon.js
+++ b/newdle/client/src/components/GridCommon.js
@@ -20,6 +20,7 @@ export function FooterCell({
   hovered,
   onMouseEnter,
   onMouseLeave,
+  limitedSlots,
 }) {
   const availableCount = participants.filter(
     ({answers}) => answers[timeslot] === 'available'
@@ -40,9 +41,9 @@ export function FooterCell({
     >
       <AvailabilityRing
         available={availableCount}
-        unavailable={unavailableCount}
+        unavailable={limitedSlots ? 0 : unavailableCount}
         ifNeeded={ifneedbeCount}
-        totalParticipants={participants.length}
+        totalParticipants={limitedSlots ? 1 : participants.length}
         radius={40}
         strokeWidth={7}
       />
@@ -62,6 +63,7 @@ FooterCell.propTypes = {
   hovered: PropTypes.bool.isRequired,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
+  limitedSlots: PropTypes.bool.isRequired,
 };
 
 export function DateCell({
@@ -71,12 +73,15 @@ export function DateCell({
   newdleDuration,
   setFinalDate,
   isCreator,
+  limitedSlots,
   interactive,
   active,
   hovered,
   onMouseEnter,
   onMouseLeave,
 }) {
+  const selectable = interactive && isCreator && !limitedSlots;
+
   const startTime = userTz
     ? toMoment(timeslot, 'YYYY-MM-DDTHH:mm', newdleTz).tz(userTz)
     : toMoment(timeslot, 'YYYY-MM-DDTHH:mm', newdleTz);
@@ -88,7 +93,7 @@ export function DateCell({
     className += ` ${styles.hover}`;
   }
 
-  if (isCreator && interactive) {
+  if (selectable) {
     className += ` ${styles.pointer}`;
   }
 
@@ -96,7 +101,7 @@ export function DateCell({
     <Table.HeaderCell
       textAlign="center"
       className={className}
-      onClick={() => interactive && isCreator && setFinalDate(timeslot)}
+      onClick={() => selectable && setFinalDate(timeslot)}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
@@ -105,7 +110,7 @@ export function DateCell({
         <div className={styles['time']}>{formatMeetingTime(startTime, newdleDuration)}</div>
         <div className={styles['timezone']}>{userTz || newdleTz}</div>
       </div>
-      {interactive && isCreator && <Radio name="slot-id" value={timeslot} checked={active} />}
+      {selectable && <Radio name="slot-id" value={timeslot} checked={active} />}
     </Table.HeaderCell>
   );
 }
@@ -117,6 +122,7 @@ DateCell.propTypes = {
   newdleDuration: PropTypes.number.isRequired,
   setFinalDate: PropTypes.func,
   isCreator: PropTypes.bool.isRequired,
+  limitedSlots: PropTypes.bool.isRequired,
   interactive: PropTypes.bool.isRequired,
   active: PropTypes.bool.isRequired,
   hovered: PropTypes.bool.isRequired,
@@ -181,6 +187,7 @@ export function TableHeader({
   finalDate,
   setFinalDate,
   isCreator,
+  limitedSlots,
   hoveredColumn,
   setHoveredColumn,
 }) {
@@ -200,8 +207,9 @@ export function TableHeader({
             interactive={interactive}
             setFinalDate={setFinalDate}
             isCreator={isCreator}
+            limitedSlots={limitedSlots}
             hovered={interactive && hoveredColumn === timeslot}
-            active={finalDate === timeslot}
+            active={!limitedSlots && finalDate === timeslot}
             onMouseEnter={interactive ? () => setHoveredColumn(timeslot) : null}
             onMouseLeave={interactive ? () => setHoveredColumn(null) : null}
           />
@@ -220,6 +228,7 @@ TableHeader.propTypes = {
   finalDate: PropTypes.string,
   setFinalDate: PropTypes.func,
   isCreator: PropTypes.bool.isRequired,
+  limitedSlots: PropTypes.bool.isRequired,
   hoveredColumn: PropTypes.string,
   setHoveredColumn: PropTypes.func,
 };
@@ -229,6 +238,7 @@ export function TableFooter({
   timeslots,
   interactive,
   finalDate,
+  limitedSlots,
   hoveredColumn,
   setHoveredColumn,
 }) {
@@ -243,9 +253,10 @@ export function TableFooter({
             timeslot={timeslot}
             interactive={interactive}
             hovered={interactive && hoveredColumn === timeslot}
-            active={finalDate === timeslot}
+            active={!limitedSlots && finalDate === timeslot}
             onMouseEnter={interactive ? () => setHoveredColumn(timeslot) : null}
             onMouseLeave={interactive ? () => setHoveredColumn(null) : null}
+            limitedSlots={limitedSlots}
           />
         ))}
       </Table.Row>
@@ -262,6 +273,7 @@ TableFooter.propTypes = {
   timeslots: PropTypes.array.isRequired,
   interactive: PropTypes.bool.isRequired,
   finalDate: PropTypes.string,
+  limitedSlots: PropTypes.bool.isRequired,
   hoveredColumn: PropTypes.string,
   setHoveredColumn: PropTypes.func,
 };

--- a/newdle/client/src/components/GridCommon.module.scss
+++ b/newdle/client/src/components/GridCommon.module.scss
@@ -19,9 +19,14 @@
     width: 100%;
   }
 
-  tr.selectable td:not(:first-child) {
-    position: relative;
-    cursor: pointer;
+  tr.selectable {
+    td:global(.selectable):not(:first-child) {
+      cursor: pointer;
+    }
+
+    td:not(:first-child) {
+      position: relative;
+    }
   }
 
   tbody tr.spacer {

--- a/newdle/client/src/components/NewdleTitle.js
+++ b/newdle/client/src/components/NewdleTitle.js
@@ -3,7 +3,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import {useHistory, useRouteMatch} from 'react-router';
 import {Trans, t} from '@lingui/macro';
 import PropTypes from 'prop-types';
-import {Container, Icon, Button, Popup, Divider} from 'semantic-ui-react';
+import {Container, Icon, Button, Popup, Divider, Label} from 'semantic-ui-react';
 import {useIsMobile} from 'src/util/hooks';
 import {toggleGridView} from '../actions';
 import {getGridViewActive, getStoredParticipantCodeForNewdle} from '../answerSelectors';
@@ -19,6 +19,7 @@ export default function NewdleTitle({
   url,
   isPrivate,
   isDeleted,
+  limitedSlots,
 }) {
   const userInfo = useSelector(getUserInfo);
   const participantCode = useSelector(state => getStoredParticipantCodeForNewdle(state, code));
@@ -52,7 +53,25 @@ export default function NewdleTitle({
             <h1 className={styles['header']}>{title}</h1>
           </div>
           <div className={styles['subtitle']}>
-            <Trans>by {author}</Trans>
+            <div className={styles['author']}>
+              <Trans>by {author}</Trans>
+            </div>
+            <div>
+              {isPrivate && (
+                <Popup
+                  mouseEnterDelay={100}
+                  trigger={<Label color="teal">private</Label>}
+                  content={<Trans>Other participants' answers are hidden</Trans>}
+                />
+              )}
+              {limitedSlots && (
+                <Popup
+                  mouseEnterDelay={100}
+                  trigger={<Label color="orange">limited</Label>}
+                  content={<Trans>You can only choose a single timeslot</Trans>}
+                />
+              )}
+            </div>
           </div>
         </div>
         <div className={styles['view-options']}>
@@ -158,6 +177,7 @@ NewdleTitle.propTypes = {
   url: PropTypes.string,
   isPrivate: PropTypes.bool,
   isDeleted: PropTypes.bool,
+  limitedSlots: PropTypes.bool,
 };
 
 NewdleTitle.defaultProps = {
@@ -166,4 +186,5 @@ NewdleTitle.defaultProps = {
   isDeleted: false,
   isPrivate: true,
   url: null,
+  limitedSlots: false,
 };

--- a/newdle/client/src/components/NewdleTitle.module.scss
+++ b/newdle/client/src/components/NewdleTitle.module.scss
@@ -15,7 +15,12 @@
 }
 
 .subtitle {
-  color: $coral;
+  display: flex;
+  gap: 1em;
+
+  .author {
+    color: $coral;
+  }
 }
 
 .box {

--- a/newdle/client/src/components/answer/AnswerHeader.js
+++ b/newdle/client/src/components/answer/AnswerHeader.js
@@ -46,6 +46,7 @@ export default function AnswerHeader({match}) {
       url={newdle.url}
       isPrivate={newdle.private}
       isDeleted={newdle.deleted}
+      limitedSlots={newdle.limited_slots}
     />
   );
 }

--- a/newdle/client/src/components/answer/DayTimeline.js
+++ b/newdle/client/src/components/answer/DayTimeline.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useDispatch} from 'react-redux';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import {Header} from 'semantic-ui-react';
@@ -10,9 +9,14 @@ import Option from './Option';
 import Slot from './Slot';
 import styles from './answer.module.scss';
 
-export default function DayTimeline({options, busySlots, selected, hourPositions}) {
+export default function DayTimeline({
+  options,
+  busySlots,
+  availableTimeslots,
+  selected,
+  hourPositions,
+}) {
   const numDaysVisible = useNumDaysVisible();
-  const dispatch = useDispatch();
   // This date does not need to be timezone casted as we are only format correcting
   const formattedDate = serializeDate(toMoment(options.date, 'YYYY-MM-DD'), 'dddd D MMM');
   const selectedDayClass = classNames(styles.date, {
@@ -32,23 +36,35 @@ export default function DayTimeline({options, busySlots, selected, hourPositions
           const size = group.length;
           if (size < 4) {
             const width = 100 / size;
-            return group.map((option, index) => (
-              <Slot
-                {...option}
-                width={width}
-                left={width * index}
-                key={option.slot}
-                className={`${styles['answer-slot']} ${styles[option.answer]}`}
-                content={<Option {...option} />}
-                onClick={() => dispatch(option.action())}
-                overlapping={size !== 1}
-              />
-            ));
+            return group.map((option, index) => {
+              const taken = !availableTimeslots.includes(option.slot);
+              return (
+                <Slot
+                  {...option}
+                  width={width}
+                  left={width * index}
+                  key={option.slot}
+                  className={`${styles['answer-slot']} ${styles[option.answer]} ${
+                    taken ? styles.taken : styles.selectable
+                  }`}
+                  content={<Option {...option} taken={taken} />}
+                  overlapping={size !== 1}
+                />
+              );
+            });
           } else {
             const height = group[size - 1].pos - group[0].pos + group[size - 1].height;
             const pos = group[0].pos;
             const key = group[0].slot;
-            return <AnswerMultipleSlot height={height} pos={pos} options={group} key={key} />;
+            return (
+              <AnswerMultipleSlot
+                height={height}
+                pos={pos}
+                options={group}
+                key={key}
+                availableTimeslots={availableTimeslots}
+              />
+            );
           }
         })}
         {busySlots &&
@@ -68,6 +84,7 @@ export default function DayTimeline({options, busySlots, selected, hourPositions
 DayTimeline.propTypes = {
   options: PropTypes.object.isRequired,
   busySlots: PropTypes.object,
+  availableTimeslots: PropTypes.array.isRequired,
   selected: PropTypes.bool.isRequired,
   hourPositions: PropTypes.array,
 };

--- a/newdle/client/src/components/answer/MultipleSlot.js
+++ b/newdle/client/src/components/answer/MultipleSlot.js
@@ -1,21 +1,25 @@
 import React from 'react';
-import {useDispatch} from 'react-redux';
 import PropTypes from 'prop-types';
 import Option from './Option';
 import styles from './answer.module.scss';
 
-export default function MultipleSlot({height, pos, options}) {
-  const dispatch = useDispatch();
+export default function MultipleSlot({height, pos, options, availableTimeslots}) {
   return (
     <div className={styles['multiple-answer-slot']} style={{top: `${pos}%`, height: `${height}%`}}>
-      {options.map(option => (
-        <Option
-          {...option}
-          styles={{height: `${height / options.length}%`}}
-          key={option.slot}
-          onClick={() => dispatch(option.action())}
-        />
-      ))}
+      {options.map(option => {
+        const taken = !availableTimeslots.includes(option.slot);
+        const className = taken ? styles.taken : `${option.className} ${styles.selectable}`;
+        return (
+          <Option
+            {...option}
+            className={className}
+            styles={{height: `${height / options.length}%`}}
+            key={option.slot}
+            slot={option.slot}
+            taken={taken}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -29,4 +33,5 @@ MultipleSlot.propTypes = {
       action: PropTypes.func.isRequired,
     })
   ).isRequired,
+  availableTimeslots: PropTypes.array.isRequired,
 };

--- a/newdle/client/src/components/answer/Option.js
+++ b/newdle/client/src/components/answer/Option.js
@@ -1,15 +1,30 @@
 import React from 'react';
+import {useDispatch} from 'react-redux';
 import PropTypes from 'prop-types';
 import {Icon} from 'semantic-ui-react';
 import styles from './answer.module.scss';
 
-export default function Option({startTime, endTime, icon, onClick, className, styles: moreStyles}) {
+export default function Option({
+  startTime,
+  endTime,
+  icon,
+  action,
+  className,
+  taken,
+  styles: moreStyles,
+}) {
+  const dispatch = useDispatch();
+
   return (
-    <div className={`${styles.option} ${className}`} onClick={onClick} style={moreStyles}>
+    <div
+      className={`${styles.option} ${className}`}
+      onClick={taken ? null : () => dispatch(action())}
+      style={{...moreStyles, cursor: taken ? 'inherit' : 'pointer'}}
+    >
       <span className={styles.times}>
         {startTime} - {endTime}
       </span>
-      <Icon name={icon} />
+      <Icon name={!taken ? icon : 'ban'} />
     </div>
   );
 }
@@ -17,10 +32,11 @@ export default function Option({startTime, endTime, icon, onClick, className, st
 Option.propTypes = {
   startTime: PropTypes.string.isRequired,
   endTime: PropTypes.string.isRequired,
-  onClick: PropTypes.func,
+  action: PropTypes.func,
   className: PropTypes.string,
   icon: PropTypes.string.isRequired,
   styles: PropTypes.object,
+  taken: PropTypes.bool.isRequired,
 };
 
 Option.defaultProps = {

--- a/newdle/client/src/components/answer/answer.module.scss
+++ b/newdle/client/src/components/answer/answer.module.scss
@@ -103,8 +103,11 @@
     position: absolute;
     border-radius: 2px;
     z-index: 1;
-    cursor: pointer;
     width: 100%;
+
+    &.selectable {
+      cursor: pointer;
+    }
 
     &:global(.overlapping):hover {
       left: 0 !important;
@@ -117,7 +120,7 @@
       background-color: #d9d9d9;
       border: 1px solid rgba($grey, 0.5);
 
-      &:global(.overlapping):hover {
+      &:global(.overlapping):not(.taken):hover {
         background-color: rgba($grey, 0.9);
         color: $light-grey;
       }
@@ -141,6 +144,16 @@
       &:global(.overlapping):hover {
         background-color: rgba($yellow, 0.9);
       }
+    }
+
+    &.taken {
+      background: repeating-linear-gradient(
+        45deg,
+        #f2f2f2,
+        #f2f2f2 10px,
+        #e4e4e4 10px,
+        #e4e4e4 20px
+      );
     }
 
     .option {
@@ -197,6 +210,16 @@
       &.ifneedbe {
         color: $dark-yellow;
         background-color: #fcf4b5;
+      }
+
+      &.taken {
+        background: repeating-linear-gradient(
+          45deg,
+          #f2f2f2,
+          #f2f2f2 10px,
+          #e4e4e4 10px,
+          #e4e4e4 20px
+        );
       }
 
       i:global(.icon) {

--- a/newdle/client/src/components/common/FinalDate.js
+++ b/newdle/client/src/components/common/FinalDate.js
@@ -5,11 +5,21 @@ import {Header, Icon} from 'semantic-ui-react';
 import {serializeDate, toMoment} from '../../util/date';
 import styles from './FinalDate.module.scss';
 
-export default function FinalDate({title, final_dt: finalDate, duration, timezone}) {
+export default function FinalDate({
+  title,
+  final_dt: finalDate,
+  duration,
+  timezone,
+  limited_slots: limitedSlots,
+}) {
   return (
     <div className={styles.container}>
       <Header className={styles.header} as="h2">
-        <Trans>{title} will take place on:</Trans>
+        {limitedSlots ? (
+          <Trans>Your selected timeslot is:</Trans>
+        ) : (
+          <Trans>{title} will take place on:</Trans>
+        )}
       </Header>
       <div className={styles.datetime}>
         <Icon name="calendar alternate outline" />
@@ -29,4 +39,5 @@ FinalDate.propTypes = {
   final_dt: PropTypes.string.isRequired,
   duration: PropTypes.number.isRequired,
   timezone: PropTypes.string.isRequired,
+  limited_slots: PropTypes.bool.isRequired,
 };

--- a/newdle/client/src/components/creation/ClonePage.js
+++ b/newdle/client/src/components/creation/ClonePage.js
@@ -53,6 +53,7 @@ export default function ClonePage() {
           title: keepSettings ? newdle.title : null,
           private: keepSettings ? newdle.private : null,
           notify: keepSettings ? newdle.notify : null,
+          limitedSlots: keepSettings ? newdle.limited_slots : null,
           participants: keepParticipants
             ? // Remove participant data (answers, comments) coming from the original newdle.
               // Participant id is needed for a key in <UserSearch> since email might be missing here.

--- a/newdle/client/src/components/creation/CreationPage.js
+++ b/newdle/client/src/components/creation/CreationPage.js
@@ -11,6 +11,7 @@ import {
   setNotification,
   setDuration,
   setTimezone,
+  setLimitedSlots,
 } from '../../actions';
 import {getStep, isLoggedIn, shouldConfirmAbortCreation} from '../../selectors';
 import {usePageTitle} from '../../util/hooks';
@@ -44,6 +45,9 @@ export default function CreationPage() {
       }
       if (cloneData.notify !== null) {
         dispatch(setNotification(cloneData.notify));
+      }
+      if (cloneData.limitedSlots !== null) {
+        dispatch(setLimitedSlots(cloneData.limitedSlots));
       }
       if (cloneData.participants.length) {
         dispatch(addParticipants(cloneData.participants));

--- a/newdle/client/src/components/creation/FinalStep.js
+++ b/newdle/client/src/components/creation/FinalStep.js
@@ -10,6 +10,7 @@ import {
   setTitle,
   setPrivate,
   setNotification,
+  setLimitedSlots,
   updateNewdle,
 } from '../../actions';
 import client from '../../client';
@@ -20,6 +21,7 @@ import {
   getTitle,
   getPrivacySetting,
   getNotifySetting,
+  getLimitedSlotsSetting,
   getCreatedNewdle,
   getParticipants,
 } from '../../selectors';
@@ -30,6 +32,7 @@ export default function FinalStep({isEditing}) {
   const title = useSelector(getTitle);
   const isPrivate = useSelector(getPrivacySetting);
   const notify = useSelector(getNotifySetting);
+  const limitedSlots = useSelector(getLimitedSlotsSetting);
   const duration = useSelector(getDuration);
   const timeslots = useSelector(getFullTimeslots);
   const participants = useSelector(getParticipants);
@@ -53,6 +56,7 @@ export default function FinalStep({isEditing}) {
       timeslots,
       participantsWithEmail,
       isPrivate,
+      limitedSlots,
       notify
     );
 
@@ -137,6 +141,23 @@ export default function FinalStep({isEditing}) {
                 onChange={(_, {checked}) => dispatch(setPrivate(checked))}
               />
             </div>
+            {!isEditing && (
+              // This setting cannot be edited after the newdle is created since
+              // there could already be multiple answers
+              <div>
+                <label htmlFor="toggleLimitedSlots">
+                  <Trans>One slot per participant</Trans>
+                </label>
+                <Checkbox
+                  className={styles['advanced-checkbox']}
+                  id="toggleLimitedSlots"
+                  toggle
+                  checked={limitedSlots}
+                  disabled={submitting}
+                  onChange={(_, {checked}) => dispatch(setLimitedSlots(checked))}
+                />
+              </div>
+            )}
             <div>
               <label htmlFor="toggleNotify">
                 <Trans>Notify me about new answers</Trans>

--- a/newdle/client/src/components/summary/SummaryHeader.js
+++ b/newdle/client/src/components/summary/SummaryHeader.js
@@ -32,6 +32,7 @@ export default function SummaryHeader({match}) {
       url={newdle.url}
       isPrivate={newdle.private}
       isDeleted={newdle.deleted}
+      limitedSlots={newdle.limited_slots}
     />
   );
 }

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Nobody has voted yet."
 msgstr ""
 
-#: src/client.js:316
+#: src/client.js:319
 msgid "Not logged in"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Your participants will receive an e-mail asking them to register to their preference. Once the newdle is created, you will be shown a link you can share with anyone else you wish to invite."
 msgstr ""
 
-#: src/client.js:240
+#: src/client.js:243
 msgid "Your selected slot is already taken"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/answer/AnswerPage.js:97
+msgid "1 option chosen"
+msgstr ""
+
 #: src/components/home/HomeHeader.js:11
 msgid "<0>newdle</0> is a collective meeting scheduling application."
 msgstr "<0>newdle</0> es una aplicación para programar reuniones colectivamente."
@@ -313,7 +317,7 @@ msgstr ""
 msgid "Next step"
 msgstr ""
 
-#: src/components/answer/Calendar.js:210
+#: src/components/answer/Calendar.js:225
 msgid "No data"
 msgstr ""
 
@@ -511,6 +515,10 @@ msgstr ""
 msgid "You can also \"Skip\" this step and simply share the link to your newdle"
 msgstr ""
 
+#: src/components/NewdleTitle.js:70
+msgid "You can only choose a single timeslot"
+msgstr ""
+
 #: src/components/home/HomeHeader.js:15
 msgid "You can use it to find out the best dates/times for your meetings."
 msgstr "Puedes usarlo para conocer los mejores dias/fechas para tus reuniones."
@@ -533,6 +541,14 @@ msgstr ""
 
 #: src/components/creation/FinalStep.js:101
 msgid "Your participants will receive an e-mail asking them to register to their preference. Once the newdle is created, you will be shown a link you can share with anyone else you wish to invite."
+msgstr ""
+
+#: src/client.js:240
+msgid "Your selected slot is already taken"
+msgstr ""
+
+#: src/components/common/FinalDate.js:19
+msgid "Your selected timeslot is:"
 msgstr ""
 
 #: src/components/login/LoginPrompt.js:25
@@ -614,6 +630,6 @@ msgstr ""
 msgid "{numberOfTimeslots, plural, one {{numberOfAvailable} out of # option chosen} other {{numberOfAvailable} out of # options chosen}}"
 msgstr ""
 
-#: src/components/common/FinalDate.js:12
+#: src/components/common/FinalDate.js:21
 msgid "{title} will take place on:"
 msgstr ""

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Clone newdle"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:93
+#: src/components/creation/ClonePage.js:94
 msgid "Cloning options"
 msgstr ""
 
@@ -146,7 +146,7 @@ msgstr ""
 msgid "Create event"
 msgstr ""
 
-#: src/components/creation/CreationPage.js:29
+#: src/components/creation/CreationPage.js:30
 msgid "Create newdle"
 msgstr ""
 
@@ -229,8 +229,8 @@ msgstr "¿Cómo funciona?"
 msgid "It is not possible to answer this newdle anymore."
 msgstr ""
 
-#: src/components/creation/ClonePage.js:113
-#: src/components/creation/ClonePage.js:120
+#: src/components/creation/ClonePage.js:114
+#: src/components/creation/ClonePage.js:121
 msgid "Keep list of participants"
 msgstr ""
 
@@ -238,16 +238,16 @@ msgstr ""
 msgid "Keep list of participants private"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:76
-#: src/components/creation/ClonePage.js:83
+#: src/components/creation/ClonePage.js:77
+#: src/components/creation/ClonePage.js:84
 msgid "Keep the timeslots as they are"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:133
+#: src/components/creation/ClonePage.js:134
 msgid "Keep timeslots"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:99
+#: src/components/creation/ClonePage.js:100
 msgid "Keep title and settings"
 msgstr ""
 
@@ -386,7 +386,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:180
+#: src/components/creation/ClonePage.js:181
 msgid "Review cloned newdle"
 msgstr ""
 
@@ -410,7 +410,7 @@ msgstr ""
 msgid "Set the time slots based on their availability"
 msgstr "Configura las franjas horarias según su disponibilidad"
 
-#: src/components/creation/ClonePage.js:154
+#: src/components/creation/ClonePage.js:155
 msgid "Set the timeslots to start at a specific date"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:78
+#: src/components/creation/ClonePage.js:79
 msgid "Some of the current timeslots are in the past"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Some of your participants do not have e-mail addresses and will not be contacted:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:115
+#: src/components/creation/ClonePage.js:116
 msgid "Some participants were not logged in and will be skipped in the cloned newdle."
 msgstr ""
 
@@ -439,7 +439,7 @@ msgstr ""
 msgid "Something went wrong when notifying participants:"
 msgstr ""
 
-#: src/components/creation/ClonePage.js:162
+#: src/components/creation/ClonePage.js:163
 msgid "Starting date:"
 msgstr ""
 

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/answer/AnswerPage.js:97
+#: src/components/answer/AnswerPage.js:114
 msgid "1 option chosen"
 msgstr ""
 
@@ -25,7 +25,7 @@ msgstr "<0>newdle</0> es una aplicación para programar reuniones colectivamente
 msgid "<0>newdle</0> will collect the answers!"
 msgstr "<0>newdle</0> guardará las respuestas"
 
-#: src/components/answer/AnswerPage.js:270
+#: src/components/answer/AnswerPage.js:308
 msgid "Accept all options where I'm available"
 msgstr ""
 
@@ -41,7 +41,7 @@ msgstr ""
 msgid "Add participant"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:121
+#: src/components/creation/FinalStep.js:125
 msgid "Advanced options"
 msgstr ""
 
@@ -49,11 +49,11 @@ msgstr ""
 msgid "All participants answered."
 msgstr ""
 
-#: src/components/NewdleTitle.js:62
+#: src/components/NewdleTitle.js:81
 msgid "Answer newdle"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:90
+#: src/components/answer/AnswerPage.js:91
 msgid "Answering on behalf of:"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Are you sure you want to leave this page without saving?"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:97
+#: src/components/creation/FinalStep.js:101
 msgid "Attention"
 msgstr ""
 
@@ -73,21 +73,21 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:326
+#: src/components/answer/AnswerPage.js:364
 msgid "Calendar"
 msgstr ""
 
 #: src/components/creation/userSearch/UserSearch.js:174
 #: src/components/login/LoginPrompt.js:45
-#: src/components/summary/SummaryPage.js:186
+#: src/components/summary/SummaryPage.js:189
 msgid "Cancel"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:182
+#: src/components/creation/FinalStep.js:203
 msgid "Change participants"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:191
+#: src/components/creation/FinalStep.js:212
 msgid "Change time slots"
 msgstr ""
 
@@ -108,8 +108,8 @@ msgid "Click to add time slots"
 msgstr ""
 
 #: src/components/creation/ClonePage.js:34
-#: src/components/summary/SummaryPage.js:216
-#: src/components/summary/SummaryPage.js:300
+#: src/components/summary/SummaryPage.js:225
+#: src/components/summary/SummaryPage.js:311
 msgid "Clone newdle"
 msgstr ""
 
@@ -120,15 +120,15 @@ msgstr ""
 #: src/components/creation/ParticipantsStep.js:61
 #: src/components/creation/timeslots/TimeslotsStep.js:103
 #: src/components/creation/userSearch/UserSearch.js:171
-#: src/components/summary/SummaryPage.js:183
+#: src/components/summary/SummaryPage.js:186
 msgid "Confirm"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:169
+#: src/components/creation/FinalStep.js:190
 msgid "Confirm changes"
 msgstr ""
 
-#: src/components/NewdleTitle.js:124
+#: src/components/NewdleTitle.js:143
 #: src/components/creation/CreationSuccessPage.js:59
 msgid "Copied!"
 msgstr ""
@@ -137,12 +137,12 @@ msgstr ""
 msgid "Copy time slots from previous day"
 msgstr ""
 
-#: src/components/NewdleTitle.js:131
+#: src/components/NewdleTitle.js:150
 #: src/components/creation/CreationSuccessPage.js:66
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:116
+#: src/components/summary/SummaryPage.js:119
 msgid "Create event"
 msgstr ""
 
@@ -154,13 +154,13 @@ msgstr ""
 msgid "Create your first newdle!"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:166
+#: src/components/creation/FinalStep.js:187
 msgid "Create your newdle!"
 msgstr ""
 
 #: src/components/summary/DeleteModal.js:96
-#: src/components/summary/SummaryPage.js:233
-#: src/components/summary/SummaryPage.js:302
+#: src/components/summary/SummaryPage.js:242
+#: src/components/summary/SummaryPage.js:313
 msgid "Delete newdle"
 msgstr ""
 
@@ -180,12 +180,12 @@ msgstr ""
 msgid "Duration"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:111
-#: src/components/summary/SummaryPage.js:156
+#: src/components/summary/SummaryPage.js:114
+#: src/components/summary/SummaryPage.js:159
 msgid "E-mail participants"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:288
+#: src/components/summary/SummaryPage.js:299
 msgid "Edit"
 msgstr ""
 
@@ -201,8 +201,12 @@ msgstr ""
 msgid "Error occurred"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:218
+#: src/components/summary/SummaryPage.js:227
 msgid "Export answers"
+msgstr ""
+
+#: src/components/summary/SummaryPage.js:296
+msgid "Finalize newdle"
 msgstr ""
 
 #: src/components/creation/CreationHeader.js:23
@@ -221,7 +225,7 @@ msgstr ""
 msgid "How does it work?"
 msgstr "¿Cómo funciona?"
 
-#: src/components/answer/AnswerPage.js:240
+#: src/components/answer/AnswerPage.js:278
 msgid "It is not possible to answer this newdle anymore."
 msgstr ""
 
@@ -230,7 +234,7 @@ msgstr ""
 msgid "Keep list of participants"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:129
+#: src/components/creation/FinalStep.js:133
 msgid "Keep list of participants private"
 msgstr ""
 
@@ -251,7 +255,7 @@ msgstr ""
 msgid "Leave a comment (optional)"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:435
+#: src/components/answer/AnswerPage.js:465
 msgid "Leave a comment..."
 msgstr ""
 
@@ -321,7 +325,7 @@ msgstr ""
 msgid "No data"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:429
+#: src/components/answer/AnswerPage.js:129
 msgid "No options chosen"
 msgstr ""
 
@@ -333,36 +337,48 @@ msgstr ""
 msgid "No users matching the criteria"
 msgstr ""
 
-#: src/components/ParticipantTable.js:94
+#: src/components/ParticipantTable.js:107
 msgid "Nobody has voted yet."
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:144
+#: src/client.js:316
+msgid "Not logged in"
+msgstr ""
+
+#: src/components/summary/SummaryPage.js:147
 msgid "Note that some of your participants did not provide an email address and thus could not be notified!"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:142
+#: src/components/creation/FinalStep.js:163
 msgid "Notify me about new answers"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:107
+#: src/components/creation/FinalStep.js:111
 msgid "Once the newdle is created, you will be shown a link which you need to send to anyone you wish to invite."
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:299
+#: src/components/creation/FinalStep.js:149
+msgid "One slot per participant"
+msgstr ""
+
+#: src/components/summary/SummaryPage.js:310
 msgid "Options"
 msgstr ""
 
-#: src/components/GridCommon.js:191
-#: src/components/summary/SummaryPage.js:297
+#: src/components/NewdleTitle.js:64
+msgid "Other participants' answers are hidden"
+msgstr ""
+
+#: src/components/GridCommon.js:198
+#: src/components/summary/SummaryPage.js:308
 msgid "Participants"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:83
+#: src/components/creation/FinalStep.js:87
 msgid "Please enter a title for your event..."
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:74
+#: src/components/answer/AnswerPage.js:75
 msgid "Please enter your name..."
 msgstr ""
 
@@ -378,7 +394,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:285
+#: src/components/summary/SummaryPage.js:296
 msgid "Select final date"
 msgstr ""
 
@@ -386,7 +402,7 @@ msgstr ""
 msgid "Select your language"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:450
+#: src/components/answer/AnswerPage.js:480
 msgid "Send your answer"
 msgstr ""
 
@@ -398,7 +414,7 @@ msgstr "Configura las franjas horarias según su disponibilidad"
 msgid "Set the timeslots to start at a specific date"
 msgstr ""
 
-#: src/components/NewdleTitle.js:120
+#: src/components/NewdleTitle.js:139
 msgid "Shareable link"
 msgstr ""
 
@@ -411,7 +427,7 @@ msgid "Some of the current timeslots are in the past"
 msgstr ""
 
 #: src/components/summary/DeleteModal.js:83
-#: src/components/summary/SummaryPage.js:165
+#: src/components/summary/SummaryPage.js:168
 msgid "Some of your participants do not have e-mail addresses and will not be contacted:"
 msgstr ""
 
@@ -419,7 +435,7 @@ msgstr ""
 msgid "Some participants were not logged in and will be skipped in the cloned newdle."
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:130
+#: src/components/summary/SummaryPage.js:133
 msgid "Something went wrong when notifying participants:"
 msgstr ""
 
@@ -427,20 +443,20 @@ msgstr ""
 msgid "Starting date:"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:56
+#: src/components/summary/SummaryPage.js:58
 msgid "Summary: {0}"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:266
+#: src/components/summary/SummaryPage.js:277
 msgid "The following participants have not voted yet:"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:140
+#: src/components/summary/SummaryPage.js:143
 msgid "The participants have been notified of the final date."
 msgstr ""
 
 #: src/components/MyNewdles.js:105
-#: src/components/ParticipantTable.js:92
+#: src/components/ParticipantTable.js:105
 msgid "There are no participants yet."
 msgstr ""
 
@@ -448,13 +464,13 @@ msgstr ""
 msgid "They will be presented as options to the participants"
 msgstr ""
 
-#: src/components/NewdleTitle.js:62
-#: src/components/answer/AnswerPage.js:239
+#: src/components/NewdleTitle.js:81
+#: src/components/answer/AnswerPage.js:277
 msgid "This newdle has already finished"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:212
-#: src/components/summary/SummaryPage.js:82
+#: src/components/answer/AnswerPage.js:245
+#: src/components/summary/SummaryPage.js:85
 msgid "This newdle has been deleted by its creator."
 msgstr ""
 
@@ -462,16 +478,24 @@ msgstr ""
 msgid "This newdle has finished"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:362
+#: src/components/answer/AnswerPage.js:400
 msgid "This page is personal and its URL should not be shared. Please use the shareable link above to share the newdle with others."
+msgstr ""
+
+#: src/components/answer/AnswerGrid.js:109
+msgid "This slot is already taken"
+msgstr ""
+
+#: src/components/ParticipantGrid.js:46
+msgid "This slot was added after the participant has already answered"
 msgstr ""
 
 #: src/components/creation/userSearch/UserSearch.js:106
 msgid "This user was not logged in and will be skipped in the cloned newdle."
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:336
-#: src/components/summary/SummaryPage.js:298
+#: src/components/answer/AnswerPage.js:374
+#: src/components/summary/SummaryPage.js:309
 msgid "Timeslots"
 msgstr ""
 
@@ -479,15 +503,15 @@ msgstr ""
 msgid "Timezone"
 msgstr ""
 
-#: src/components/NewdleTitle.js:94
+#: src/components/NewdleTitle.js:113
 msgid "Toggle grid view"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:450
+#: src/components/answer/AnswerPage.js:480
 msgid "Update your answer"
 msgstr ""
 
-#: src/components/NewdleTitle.js:77
+#: src/components/NewdleTitle.js:96
 msgid "View summary"
 msgstr ""
 
@@ -503,7 +527,7 @@ msgstr ""
 msgid "Welcome to newdle!"
 msgstr "Bienvenido a newdle!"
 
-#: src/components/answer/AnswerPage.js:68
+#: src/components/answer/AnswerPage.js:69
 msgid "Who are you?"
 msgstr ""
 
@@ -515,7 +539,7 @@ msgstr ""
 msgid "You can also \"Skip\" this step and simply share the link to your newdle"
 msgstr ""
 
-#: src/components/NewdleTitle.js:70
+#: src/components/NewdleTitle.js:71
 msgid "You can only choose a single timeslot"
 msgstr ""
 
@@ -527,7 +551,7 @@ msgstr "Puedes usarlo para conocer los mejores dias/fechas para tus reuniones."
 msgid "You need to log in to access this page"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:353
+#: src/components/answer/AnswerPage.js:391
 msgid "Your answer has been saved!"
 msgstr ""
 
@@ -539,7 +563,7 @@ msgstr ""
 msgid "Your newdle was created. You can now send the following to everyone you would like to invite:"
 msgstr ""
 
-#: src/components/creation/FinalStep.js:101
+#: src/components/creation/FinalStep.js:105
 msgid "Your participants will receive an e-mail asking them to register to their preference. Once the newdle is created, you will be shown a link you can share with anyone else you wish to invite."
 msgstr ""
 
@@ -555,7 +579,7 @@ msgstr ""
 msgid "Your session expired"
 msgstr ""
 
-#: src/components/NewdleTitle.js:55
+#: src/components/NewdleTitle.js:57
 msgid "by {author}"
 msgstr ""
 
@@ -573,11 +597,11 @@ msgstr ""
 msgid "ongoing"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:291
+#: src/components/answer/AnswerPage.js:329
 msgid "originally created in the <0>{newdleTz}</0> timezone"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:307
+#: src/components/answer/AnswerPage.js:345
 msgid "switch back to the <0>{defaultUserTz}</0> timezone"
 msgstr ""
 
@@ -585,7 +609,7 @@ msgstr ""
 msgid "{0, plural, =0 {No participants registered} one {# participant registered} other {# participants registered}}"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:173
+#: src/components/summary/SummaryPage.js:176
 msgid "{0, plural, one {# participant will be e-mailed:} other {# participants will be e-mailed:}}"
 msgstr ""
 
@@ -602,11 +626,15 @@ msgstr ""
 msgid "{0, plural, one {{1} out of # participant answered} other {{2} out of # participants answered}}"
 msgstr ""
 
-#: src/components/summary/SummaryPage.js:192
+#: src/components/summary/SummaryPage.js:196
+msgid "{0} has been finalized"
+msgstr ""
+
+#: src/components/summary/SummaryPage.js:198
 msgid "{0} will take place on:"
 msgstr ""
 
-#: src/components/ParticipantTable.js:154
+#: src/components/ParticipantTable.js:172
 msgid "{availableCount, plural, one {# available participant} other {# available participants}}"
 msgstr ""
 
@@ -626,7 +654,7 @@ msgstr ""
 msgid "{numSlots, plural, one {<0>#</0> slot selected} other {<1>#</1> slots selected} =0 {You haven't selected any slots yet}}"
 msgstr ""
 
-#: src/components/answer/AnswerPage.js:421
+#: src/components/answer/AnswerPage.js:116
 msgid "{numberOfTimeslots, plural, one {{numberOfAvailable} out of # option chosen} other {{numberOfAvailable} out of # options chosen}}"
 msgstr ""
 

--- a/newdle/client/src/reducers/creation.js
+++ b/newdle/client/src/reducers/creation.js
@@ -17,6 +17,7 @@ import {
   SET_PRIVATE,
   SET_NOTIFICATION,
   NEWDLE_RECEIVED,
+  SET_LIMITED_SLOTS,
 } from '../actions';
 
 const DEFAULT_DURATION = 30;
@@ -173,6 +174,20 @@ export default combineReducers({
         return false;
       case SET_PRIVATE:
         return action.private;
+      default:
+        return state;
+    }
+  },
+  limitedSlots: (state = false, action) => {
+    switch (action.type) {
+      case NEWDLE_RECEIVED:
+        // Deleted newdles don't have a value here
+        return action.newdle.limitedSlots === undefined ? null : action.newdle.limitedSlots;
+      case ABORT_CREATION:
+      case NEWDLE_CREATED:
+        return false;
+      case SET_LIMITED_SLOTS:
+        return action.limitedSlots;
       default:
         return state;
     }

--- a/newdle/client/src/selectors.js
+++ b/newdle/client/src/selectors.js
@@ -70,6 +70,7 @@ export const shouldConfirmAbortCreation = createSelector(
 );
 export const getTitle = state => state.creation.title;
 export const getPrivacySetting = state => state.creation.private;
+export const getLimitedSlotsSetting = state => state.creation.limitedSlots;
 export const getNotifySetting = state => state.creation.notify;
 export const getFullTimeslots = state =>
   [].concat(
@@ -83,6 +84,7 @@ export const getNewdle = state => state.newdle;
 export const getNewdleTimezone = state => state.newdle && state.newdle.timezone;
 export const getNewdleTimeslots = state => (state.newdle && state.newdle.timeslots) || [];
 export const getNewdleDuration = state => state.newdle && state.newdle.duration;
+export const hasLimitedSlots = state => state.newdle && state.newdle.limited_slots;
 export const getNewdleParticipants = state => (state.newdle && state.newdle.participants) || [];
 export const getNumberOfParticipants = createSelector(
   getNewdleParticipants,

--- a/newdle/migrations/versions/20220429_0945_30b5fe7b5949_add_limited_slots.py
+++ b/newdle/migrations/versions/20220429_0945_30b5fe7b5949_add_limited_slots.py
@@ -1,0 +1,29 @@
+"""Add 'limited_slots' column to newdles
+
+Revision ID: 30b5fe7b5949
+Revises: 28103ebec68e
+Create Date: 2022-04-29 09:45:12.950683
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '30b5fe7b5949'
+down_revision = '28103ebec68e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'newdles',
+        sa.Column(
+            'limited_slots', sa.Boolean(), nullable=False, server_default='false'
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column('newdles', 'limited_slots')

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -45,7 +45,7 @@ class Newdle(db.Model):
     duration = db.Column(db.Interval, nullable=False)
     timezone = db.Column(db.String, nullable=False)
     timeslots = db.Column(ARRAY(db.DateTime()), nullable=False)
-    limited_slots = db.Column(db.Boolean, nullable=False, default=False)
+    limited_slots = db.Column(db.Boolean, nullable=False, server_default='false')
     final_dt = db.Column(db.DateTime(), nullable=True)
     deletion_dt = db.Column(db.DateTime(), nullable=True)
     last_update = db.Column(

--- a/newdle/models.py
+++ b/newdle/models.py
@@ -98,12 +98,13 @@ class Newdle(db.Model):
         if not self.limited_slots:
             return self.timeslots
 
-        slots = {slot for slot in self.timeslots}
-        for p in self.participants:
-            for slot, answer in p.answers.items():
-                if answer == Availability.available:
-                    slots.discard(slot)
-        return sorted(list(slots))
+        used_slots = {
+            slot
+            for p in self.participants
+            for slot, answer in p.answers.items()
+            if answer == Availability.available
+        }
+        return sorted(set(self.timeslots) - used_slots)
 
     def __repr__(self):
         return '<Newdle {}{}: "{}">'.format(

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -219,7 +219,6 @@ class DeletedNewdleSchema(NewdleSchema):
             'code',
             'deleted',
             'title',
-            'available_timeslots',
         )
 
 

--- a/newdle/schemas.py
+++ b/newdle/schemas.py
@@ -165,6 +165,7 @@ class NewNewdleSchema(mm.Schema):
         validate=bool,
         required=True,
     )
+    limited_slots = fields.Boolean()
     participants = fields.List(
         fields.Nested(NewKnownParticipantSchema, unknown=EXCLUDE), missing=[]
     )
@@ -196,6 +197,7 @@ class NewdleSchema(NewNewdleSchema):
     private = fields.Boolean()
     notify = fields.Boolean()
     deleted = fields.Boolean()
+    available_timeslots = fields.List(fields.DateTime(format=DATETIME_FORMAT))
 
 
 class MyNewdleSchema(NewdleSchema):
@@ -210,7 +212,15 @@ class RestrictedNewdleSchema(NewdleSchema):
 
 class DeletedNewdleSchema(NewdleSchema):
     class Meta:
-        fields = ('id', 'creator_name', 'creator_uid', 'code', 'deleted', 'title')
+        fields = (
+            'id',
+            'creator_name',
+            'creator_uid',
+            'code',
+            'deleted',
+            'title',
+            'available_timeslots',
+        )
 
 
 class NewdleParticipantSchema(ParticipantSchema):

--- a/newdle/templates/result_email_limited_slots.html
+++ b/newdle/templates/result_email_limited_slots.html
@@ -1,0 +1,31 @@
+{% extends 'base_email.html' %}
+
+{% block content %}
+  <p>
+    Hi {{ participant }}
+  </p>
+
+  <table border="0" cellpadding="0" cellspacing="0"
+         style="padding: 20px; margin: 35px auto 0 auto; border-radius: 5px; background: #ffe6e8; min-width: 550px;">
+    <tr>
+      <td style="border: 0; padding: 0;">
+        <p>
+          <b>{{ creator }}</b> confirmed your answer for the event "<b>{{ title }}</b>":
+        </p>
+        <p style="text-align: center; font-size: 19px;">
+          <i>
+            {{ date }}<br>
+            {{ start_time }} - {{ end_time }}<br>
+            <span style="font-size: 16px;">({{ timezone }})</span>
+          </i>
+        </p>
+      </td>
+    </tr>
+  </table>
+  <p style="margin: 30px 0 15px">
+    <a href="{{ newdle_link }}"
+       style="background: #2389D7; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 200px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none; text-decoration: none;">
+      Go to the newdle
+    </a>
+  </p>
+{% endblock %}

--- a/newdle/templates/result_email_limited_slots.txt
+++ b/newdle/templates/result_email_limited_slots.txt
@@ -1,0 +1,10 @@
+{% extends 'base_email.txt' %}
+{% block content -%}
+    Hi {{ participant }},
+
+    {{ creator }} confirmed your answer for the event "{{ title }}".
+
+    Your chosen timeslot is:
+    {{ date }}
+    {{ start_time }} - {{ end_time }} ({{ timezone }})
+{%- endblock %}

--- a/tests/answers_test.py
+++ b/tests/answers_test.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+
+from newdle.answers import validate_answers
+from newdle.models import Availability, Participant
+
+
+def test_validate_answers(db_session, dummy_newdle):
+    dummy_newdle.timeslots = [
+        datetime.fromisoformat('2022-05-05T10:00:00'),
+        datetime.fromisoformat('2022-05-06T10:00:00'),
+        datetime.fromisoformat('2022-05-07T10:00:00'),
+        datetime.fromisoformat('2022-05-08T10:00:00'),
+    ]
+    db_session.commit()
+
+    participant = Participant(
+        name='John Doe',
+        email='john.doe@cern.ch',
+        auth_uid='1234',
+        answers={
+            dummy_newdle.timeslots[0]: Availability.available,
+            dummy_newdle.timeslots[1]: Availability.ifneedbe,
+            dummy_newdle.timeslots[2]: Availability.unavailable,
+        },
+    )
+    dummy_newdle.participants.add(participant)
+    dummy_newdle.update_lastmod()
+    db_session.commit()
+
+    # nonexistent timeslot
+    answers = {
+        datetime.fromisoformat('1958-05-05T10:00:00'): Availability.available,
+    }
+
+    err = validate_answers(dummy_newdle, participant, answers)
+    assert err is not None
+
+    answers = {
+        dummy_newdle.timeslots[3]: Availability.available,
+    }
+
+    err = validate_answers(dummy_newdle, participant, answers)
+    assert err is None
+
+
+def test_validate_answers_limited_slots(db_session, dummy_newdle):
+    dummy_newdle.timeslots = [
+        datetime.fromisoformat('2022-05-05T10:00:00'),
+        datetime.fromisoformat('2022-05-06T10:00:00'),
+        datetime.fromisoformat('2022-05-07T10:00:00'),
+        datetime.fromisoformat('2022-05-08T10:00:00'),
+    ]
+    dummy_newdle.limited_slots = True
+    db_session.commit()
+
+    john = Participant(
+        name='John Doe',
+        email='john.doe@cern.ch',
+        auth_uid='1234',
+        answers={
+            dummy_newdle.timeslots[0]: Availability.available,
+        },
+    )
+    amy = Participant(
+        name='Amy Wang',
+        email='amy.wang@cern.ch',
+        auth_uid='5678',
+        answers={
+            dummy_newdle.timeslots[1]: Availability.available,
+        },
+    )
+    dummy_newdle.participants.add(john)
+    dummy_newdle.participants.add(amy)
+    dummy_newdle.update_lastmod()
+    db_session.commit()
+
+    answers = {
+        dummy_newdle.timeslots[2]: Availability.ifneedbe,
+        dummy_newdle.timeslots[3]: Availability.available,
+    }
+    # 'ifneedbe' is not allowed
+    err = validate_answers(dummy_newdle, john, answers)
+    assert err is not None
+
+    answers = {
+        dummy_newdle.timeslots[2]: Availability.available,
+        dummy_newdle.timeslots[3]: Availability.available,
+    }
+    # cannot have multiple 'available'
+    err = validate_answers(dummy_newdle, john, answers)
+    assert err is not None
+
+    answers = {
+        dummy_newdle.timeslots[1]: Availability.available,
+    }
+    # timeslot already taken
+    err = validate_answers(dummy_newdle, john, answers)
+    assert err is not None
+    assert err['code'] == 409
+
+    answers = {
+        dummy_newdle.timeslots[3]: Availability.available,
+    }
+    err = validate_answers(dummy_newdle, john, answers)
+    assert err is None
+
+    answers = {
+        dummy_newdle.timeslots[3]: Availability.unavailable,
+    }
+    # No 'available' answer is also possible
+    err = validate_answers(dummy_newdle, john, answers)
+    assert err is None

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -108,6 +108,7 @@ def test_create_newdle(flask_client, dummy_uid, with_participants):
             else [],
             'private': True,
             'notify': True,
+            'limited_slots': False,
         },
     )
     assert resp.status_code == 200
@@ -139,9 +140,11 @@ def test_create_newdle(flask_client, dummy_uid, with_participants):
         'final_dt': None,
         'participants': expected_participants,
         'timeslots': ['2019-09-11T13:00', '2019-09-11T15:00'],
+        'available_timeslots': ['2019-09-11T13:00', '2019-09-11T15:00'],
         'timezone': 'Europe/Zurich',
         'private': True,
         'notify': True,
+        'limited_slots': False,
         'title': 'My Newdle',
         'deleted': False,
         'deletion_dt': None,
@@ -180,6 +183,7 @@ def test_create_newdle_duplicate_timeslot(flask_client, dummy_uid):
             'timezone': 'Europe/Zurich',
             'private': True,
             'notify': True,
+            'limited_slots': False,
             'timeslots': ['2019-09-11T13:00', '2019-09-11T13:00'],
         },
     )
@@ -209,6 +213,7 @@ def test_create_newdle_participant_email_sending(flask_client, dummy_uid, mail_q
                     'signature': '-',
                 }
             ],
+            'limited_slots': False,
             'private': True,
             'notify': True,
         },
@@ -468,6 +473,13 @@ def test_get_my_newdles(flask_client, dummy_uid, dummy_newdle):
             ],
             'private': True,
             'notify': False,
+            'limited_slots': False,
+            'available_timeslots': [
+                '2019-09-11T13:00',
+                '2019-09-11T14:00',
+                '2019-09-12T13:00',
+                '2019-09-12T13:30',
+            ],
             'timezone': 'Europe/Zurich',
             'title': 'Test event',
             'url': 'http://flask.test/newdle/dummy',
@@ -498,7 +510,14 @@ def test_get_newdle(flask_client, dummy_newdle):
         'id': dummy_newdle.id,
         'private': True,
         'notify': False,
+        'limited_slots': False,
         'timeslots': [
+            '2019-09-11T13:00',
+            '2019-09-11T14:00',
+            '2019-09-12T13:00',
+            '2019-09-12T13:30',
+        ],
+        'available_timeslots': [
             '2019-09-11T13:00',
             '2019-09-11T14:00',
             '2019-09-12T13:00',
@@ -545,7 +564,14 @@ def test_update_newdle(flask_client, dummy_newdle, dummy_uid):
         'id': dummy_newdle.id,
         'private': True,
         'notify': False,
+        'limited_slots': False,
         'timeslots': [
+            '2019-08-11T13:00',
+            '2019-08-11T14:00',
+            '2019-09-12T13:00',
+            '2019-09-12T13:30',
+        ],
+        'available_timeslots': [
             '2019-08-11T13:00',
             '2019-08-11T14:00',
             '2019-09-12T13:00',
@@ -765,7 +791,14 @@ def test_newdles_participating(flask_client, dummy_newdle, dummy_participant_uid
                     'id': dummy_newdle.id,
                     'private': True,
                     'notify': False,
+                    'limited_slots': False,
                     'timeslots': [
+                        '2019-09-11T13:00',
+                        '2019-09-11T14:00',
+                        '2019-09-12T13:00',
+                        '2019-09-12T13:30',
+                    ],
+                    'available_timeslots': [
                         '2019-09-11T13:00',
                         '2019-09-11T14:00',
                         '2019-09-12T13:00',


### PR DESCRIPTION
Closes #337 
Closes #385 

This PR adds a new type of newdle in which every participant can only choose a single timeslot and cannot choose
a timeslot which has already been selected by someone else.

Quick summary:
- `ifneedbe` is not used with this type - only `[un]available`
- selecting a slot automatically deselects other slots
- slots which are taken are disabled (and marked as such) and participants cannot select them
- changing a newdle to a newdle with limited slots is not allowed to prevent situations where participants have already answered with multiple slots, `ifneedbe`'s, etc.. 
- instead of selecting a final date, you simply _finalize_ the newdle
- when sending emails, every participant gets and email with their chosen slot
- added labels to the newdle header which indicate that the newdle has limited slots (maybe we could find a better name for that?) and that it is private
- availability rings are {0,1}/1 since every timeslot can be chosen by only one participant
- the summary view shows only participants who selected the given timeslot (since everyone else is implicitly unavailable)

![image](https://user-images.githubusercontent.com/8739637/167382256-de1ce9f1-85df-420b-b296-bdb8edf02bff.png)

![image](https://user-images.githubusercontent.com/8739637/167382571-97ff8024-2b94-4357-90dc-8cb4dd326867.png)
![image](https://user-images.githubusercontent.com/8739637/167382638-2765fe26-88d6-471c-99b7-4dbdd594eb60.png)

![image](https://user-images.githubusercontent.com/8739637/167382683-1827569d-6faf-4e11-8ee0-30d8cba91785.png)
