### PR TITLE
Fix incorrectly disabling timeslots when removing an answer

### DIFF
--- a/newdle/client/src/answerSelectors.js
+++ b/newdle/client/src/answerSelectors.js
@@ -16,19 +16,13 @@ export const hasLimitedSlots = state => state.answer.newdle && state.answer.newd
 export const getNewdleTimeslots = state =>
   (state.answer.newdle && state.answer.newdle.timeslots) || [];
 export const getNumberOfTimeslots = createSelector(getNewdleTimeslots, slots => slots.length);
-export const getAvailableTimeslots = createSelector(
-  hasLimitedSlots,
-  getNewdleTimeslots,
-  state => (state.answer.newdle && state.answer.newdle.available_timeslots) || [],
-  getParticipantAnswers,
-  (limitedSlots, timeslots, availableTimeslots, answers) => {
-    if (!limitedSlots) {
-      return timeslots;
-    }
-    const available = Object.keys(answers).filter(slot => answers[slot] === 'available');
-    return availableTimeslots.concat(available);
-  }
-);
+/**
+ * Returns the available timeslots (i.e. the slots that can be selected) for a given participant.
+ * If the newdle does not have limited slots, it just returns all timeslots.
+ * Otherwise, it returns `newdle.available_timeslots` combined with the participant's
+ * selected timeslot (so that they can {un}select it).
+ */
+export const getAvailableTimeslots = state => state.answer.availableTimeslots;
 export const getUserTimezone = state => state.answer.userTimezone;
 export const getLocalNewdleTimeslots = createSelector(
   getNewdleTimeslots,

--- a/newdle/client/src/reducers/answer.js
+++ b/newdle/client/src/reducers/answer.js
@@ -141,4 +141,26 @@ export default combineReducers({
         return state;
     }
   },
+
+  availableTimeslots: (state = [], action) => {
+    // We never remove timeslots from here, only add them.
+    // This prevents the case when a user unselects an answer and saves,
+    // which causes the answer to become disabled. This is because when
+    // submitting an answer, the newdle is not refetched so we have
+    // outdated `newdle.available_timeslots`.
+    // We circumvent this by keeping the updated list of availbale slots locally.
+    switch (action.type) {
+      case ANSWER_NEWDLE_RECEIVED:
+        return [...new Set(state.concat(action.newdle.available_timeslots))];
+      case PARTICIPANT_RECEIVED:
+        const available = Object.keys(action.participant.answers).filter(
+          slot => action.participant.answers[slot] === 'available'
+        );
+        return [...new Set(state.concat(available))];
+      case ABORT_ANSWERING:
+        return [];
+      default:
+        return state;
+    }
+  },
 });


### PR DESCRIPTION
Caused by outdated `available_timeslots`.
Refetching causes even more fetches so the solution is to
keep track of the available slots locally