### PR TITLE
Prevent popup from flickering when hovering a time slot

### DIFF
--- a/newdle/client/src/components/creation/timeslots/Slot.js
+++ b/newdle/client/src/components/creation/timeslots/Slot.js
@@ -5,21 +5,19 @@ import styles from './Timeline.module.scss';
 
 export default function Slot({width, pos, moreStyles, onClick, children, tooltip}) {
   return (
-    <Popup
-      position="top center"
-      mouseEnterDelay={100}
-      trigger={
-        <div
-          onClick={onClick}
-          className={`${styles['slot']} ${moreStyles}`}
-          style={{left: `${pos}%`, width: `${width}%`}}
-        >
-          {children}
-        </div>
-      }
-      content={tooltip}
-      disabled={!tooltip}
-    />
+    <div
+      className={`${styles['slot']} ${moreStyles}`}
+      style={{left: `${pos}%`, width: `${width}%`}}
+    >
+      <Popup
+        position="top center"
+        mouseEnterDelay={100}
+        trigger={<div onClick={onClick} style={{height: '100%', width: `100%`}} />}
+        content={tooltip}
+        disabled={!tooltip}
+      />
+      {children}
+    </div>
   );
 }
 


### PR DESCRIPTION
This happens when the popup covers a part of the trigger when it renders which prevents the original hover event which hides the popup again and so on.

The problem here was the 'x' delete icon of the time slot which was being covered by the popup. The solution is to make only the slot itself as the trigger.

Another option would be to use the `hoverable` or `offset` props of SUI's <Popup />, but `hoverable` would not be that
user friendly since the tooltips are relatively large and cover other timeslots. `offset` would imo also look a bit weird since the offset would be need to be large to prevent the overlap.