### PR TITLE
Increase max newdle duration

### DIFF
--- a/newdle/client/src/components/creation/timeslots/DurationPicker.js
+++ b/newdle/client/src/components/creation/timeslots/DurationPicker.js
@@ -58,7 +58,10 @@ export default function DurationPicker({minDuration, maxDuration, interval}) {
           popupClassName={styles['duration-input']}
           open={durationPickerOpen}
           onOpen={() => setDurationPickerOpen(true)}
-          onClose={() => setDurationPickerOpen(false)}
+          onClose={() => {
+            setDurationPickerOpen(false);
+            setShowCustomDuration(false);
+          }}
           showSecond={false}
           value={toMoment('00:00', 'HH:mm').add(duration, 'm')}
           format="H[h] mm[min]"

--- a/newdle/client/src/components/creation/timeslots/DurationPicker.js
+++ b/newdle/client/src/components/creation/timeslots/DurationPicker.js
@@ -11,7 +11,7 @@ import {toMoment} from '../../../util/date';
 import 'rc-time-picker/assets/index.css';
 import styles from './DurationPicker.module.scss';
 
-const MAX_DURATION_HOURS = 8;
+const MAX_DURATION_HOURS = 16;
 
 function _minutesToHM(minutes) {
   const hours = Math.floor(minutes / 60);


### PR DESCRIPTION
From a SNOW ticket
- Increased maximum newdle duration from 8 -> 16 hours
- Small QoL change: hide the time picker and show the original dropdown once a custom duration is selected