### PR TITLE
[Fix] NPM install failure

### DIFF
--- a/install_node.sh
+++ b/install_node.sh
@@ -7,6 +7,12 @@ mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key |
     gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 
+# Fixes issue of npm installing in docker
+# Workaround is to pin the deb.nodesource.com repository
+echo "Package: nodejs" >> /etc/apt/preferences.d/preferences \
+    && echo "Pin: origin deb.nodesource.com" >> /etc/apt/preferences.d/preferences \
+    && echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/preferences
+
 # Create node deb repository
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list


### PR DESCRIPTION
- Fixes the issue of `npm` not being stalled in docker by pining the repo in the install script
Seems to be issue with the main install script as well. Workaround tested and working.