### PR TITLE
Use flask-caching to store exchange token

### DIFF
--- a/newdle/cli.py
+++ b/newdle/cli.py
@@ -95,7 +95,7 @@ def get_exchange_token(force, dump_token):
         print('exchangelib is not available')
         sys.exit(1)
 
-    app, cache, cache_file = get_msal_app()
+    app, token_cache = get_msal_app()
     username = current_app.config['EXCHANGE_PROVIDER_ACCOUNT']
     if token := get_msal_token(force=force):
         print(f'Got access token for {username}')
@@ -120,7 +120,7 @@ def get_exchange_token(force, dump_token):
     assert len(accounts) == 1
     assert accounts[0]['username'] == username
 
-    save_msal_cache(cache, cache_file)
+    save_msal_cache(token_cache)
     print(f'Got access token for {username}')
     if dump_token:
         print(result['access_token'])

--- a/newdle/newdle.cfg.example
+++ b/newdle/newdle.cfg.example
@@ -89,7 +89,6 @@ FREE_BUSY_PROVIDERS = {'random'}
 # flow enabled):
 # EXCHANGE_PROVIDER_CLIENT_ID = 'azure app client id'
 # EXCHANGE_PROVIDER_AUTHORITY = 'https://login.microsoftonline.com/acme.com'
-# EXCHANGE_PROVIDER_CACHE_FILE = '/tmp/newdle-exchange-cache.json'
 
 EXCHANGE_DOMAIN = ''
 EXCHANGE_PROVIDER_SERVER = ''
@@ -97,7 +96,6 @@ EXCHANGE_PROVIDER_ACCOUNT = ''
 EXCHANGE_PROVIDER_CREDENTIALS = ('', '')
 EXCHANGE_PROVIDER_CLIENT_ID = ''
 EXCHANGE_PROVIDER_AUTHORITY = ''
-EXCHANGE_PROVIDER_CACHE_FILE = '/tmp/newdle-exchange-cache.json'
 
 # OX free/busy configuration
 #

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ marshmallow
 psycopg2
 python-dotenv
 pytz
+redis
 requests
 sqlalchemy
 webargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,6 +99,8 @@ pytz==2024.1
     # via
     #   -r requirements.in
     #   icalendar
+redis==5.0.7
+    # via -r requirements.in
 requests==2.31.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
This allows using e.g. the redis backend which won't result in corruption when two request update the token at the exact same time.