### PR TITLE
Use mouse click to add a new time slot

### DIFF
--- a/newdle/client/src/components/creation/timeslots/CandidatePlaceholder.js
+++ b/newdle/client/src/components/creation/timeslots/CandidatePlaceholder.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Popup} from 'semantic-ui-react';
+/**
+ * Displays a placeholder for a candidate time slot when the Timeline is hovered.
+ */
+export default function CandidatePlaceholder({visible, left, width, time}) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Popup
+      content={time}
+      open={true}
+      position="top center"
+      trigger={
+        <div
+          style={{
+            boxSizing: 'border-box',
+            position: 'absolute',
+            left: `${left}%`,
+            width: `${width}%`,
+            top: 5,
+            height: 'calc(100% - 10px)',
+            zIndex: 1000,
+            background: 'rgba(0, 0, 0, 0.2)',
+            borderRadius: '3px',
+            display: 'block',
+            pointerEvents: 'none',
+          }}
+        />
+      }
+    />
+  );
+}
+
+CandidatePlaceholder.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  width: PropTypes.number.isRequired,
+  left: PropTypes.number.isRequired,
+  time: PropTypes.string.isRequired,
+};

--- a/newdle/client/src/components/creation/timeslots/CandidateSlot.js
+++ b/newdle/client/src/components/creation/timeslots/CandidateSlot.js
@@ -16,6 +16,7 @@ function SlotEditWidget({startTime, onChange, isValidTime, slot}) {
     <Popup
       className={styles['timepicker-popup']}
       on="click"
+      onClick={e => e.stopPropagation()}
       content={
         <>
           <TimePicker
@@ -63,11 +64,14 @@ export default function CandidateSlot({
   endTime,
   onDelete,
   onChangeSlotTime,
+  onMouseEnter,
+  onMouseLeave,
   isValidTime,
   text,
 }) {
   const slot = (
     <Slot
+      onClick={e => e.stopPropagation()}
       width={width}
       pos={pos}
       moreStyles={styles['candidate']}
@@ -82,6 +86,8 @@ export default function CandidateSlot({
         name="times circle outline"
         onClick={onDelete}
         className={`${styles['clickable']} ${styles['delete-btn']}`}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
       />
     </Slot>
   );
@@ -102,6 +108,8 @@ CandidateSlot.propTypes = {
   endTime: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
   onChangeSlotTime: PropTypes.func.isRequired,
+  onMouseEnter: PropTypes.func.isRequired,
+  onMouseLeave: PropTypes.func.isRequired,
   isValidTime: PropTypes.func.isRequired,
   text: PropTypes.string,
 };

--- a/newdle/client/src/components/creation/timeslots/Timeline.module.scss
+++ b/newdle/client/src/components/creation/timeslots/Timeline.module.scss
@@ -2,17 +2,19 @@
 
 $row-height: 50px;
 $label-width: 180px;
+$rows-border-width: 5px;
 
 .timeline {
   position: relative;
   margin: 4px;
 
-  @media screen and (min-width: 1200px) {
-    margin-left: $label-width;
-  }
   .timeline-title {
     display: flex;
     justify-content: space-between;
+
+    @media screen and (min-width: 1200px) {
+      margin-left: $label-width;
+    }
   }
 
   .timeline-date {
@@ -20,8 +22,8 @@ $label-width: 180px;
   }
 
   .timeline-hours {
-    margin-left: 30px;
-    margin-right: 10px;
+    margin-left: $rows-border-width;
+    margin-right: $rows-border-width;
     color: $grey;
     height: $row-height;
     position: relative;
@@ -35,10 +37,6 @@ $label-width: 180px;
     }
   }
 
-  .timeline-slot-picker {
-    margin-left: 10px;
-    margin-right: 10px;
-  }
   @media screen and (min-width: 990px) {
     .timeline-slot-picker {
       //breakpoint happens at 990, if no width specified, the view is jumpy
@@ -48,8 +46,9 @@ $label-width: 180px;
   }
   .timeline-rows {
     position: relative;
-    margin-left: 20px;
-    margin-right: 10px;
+    background-color: lighten($green, 27%);
+    border: $rows-border-width solid lighten($green, 22%);
+
     .timeline-row {
       height: $row-height;
       display: flex;
@@ -140,6 +139,7 @@ $label-width: 180px;
     z-index: 1;
 
     &.candidate {
+      box-sizing: border-box;
       background-color: $green;
       border: 1px solid darken($green, 4%);
       height: 40px;
@@ -176,6 +176,11 @@ $label-width: 180px;
     margin-left: -5px;
   }
 
+  .add-first-text {
+    color: $grey;
+    margin-top: 10px;
+  }
+
   .timeline-input {
     opacity: 0.6;
     display: flex;
@@ -185,7 +190,7 @@ $label-width: 180px;
     border-radius: 3px;
     box-sizing: content-box;
     flex-basis: 100%;
-    margin-left: 5px;
+    cursor: pointer;
 
     .timeline-candidates {
       display: flex;
@@ -211,10 +216,13 @@ $label-width: 180px;
     }
 
     &.edit {
-      background-color: lighten($green, 27%);
-      border: 5px solid lighten($green, 22%);
-      margin: -5px -40px;
-      padding: 10px;
+      padding-top: 10px;
+      padding-bottom: 10px;
+
+      .add-btn-wrapper {
+        display: flex;
+        align-items: center;
+      }
 
       .add-btn {
         margin-left: auto;

--- a/newdle/client/src/locales/es/messages.po
+++ b/newdle/client/src/locales/es/messages.po
@@ -111,7 +111,11 @@ msgstr ""
 msgid "Choose your participants"
 msgstr "Elige a los participantes"
 
-#: src/components/creation/timeslots/Timeline.js:289
+#: src/components/creation/timeslots/Timeline.js:462
+msgid "Click the timeline to add your first time slot"
+msgstr ""
+
+#: src/components/creation/timeslots/Timeline.js:408
 msgid "Click to add time slots"
 msgstr ""
 
@@ -141,7 +145,7 @@ msgstr ""
 msgid "Copied!"
 msgstr ""
 
-#: src/components/creation/timeslots/Timeline.js:294
+#: src/components/creation/timeslots/Timeline.js:413
 msgid "Copy time slots from previous day"
 msgstr ""
 
@@ -402,7 +406,7 @@ msgstr ""
 msgid "Please log in again to confirm your identity"
 msgstr ""
 
-#: src/components/creation/timeslots/Timeline.js:373
+#: src/components/creation/timeslots/Timeline.js:520
 msgid "Revert to the local timezone"
 msgstr ""
 
@@ -519,11 +523,11 @@ msgstr ""
 msgid "Timeslots"
 msgstr ""
 
-#: src/components/creation/timeslots/Timeline.js:381
+#: src/components/creation/timeslots/Timeline.js:528
 msgid "Timezone"
 msgstr ""
 
-#: src/components/creation/timeslots/Timeline.js:379
+#: src/components/creation/timeslots/Timeline.js:526
 msgid "Timezone {revertIcon}"
 msgstr ""
 
@@ -633,7 +637,7 @@ msgstr ""
 msgid "switch back to the <0>{defaultUserTz}</0> timezone"
 msgstr ""
 
-#: src/components/creation/timeslots/Timeline.js:227
+#: src/components/creation/timeslots/Timeline.js:316
 msgid "{0, plural, =0 {No participants registered} one {# participant registered} other {# participants registered}}"
 msgstr ""
 

--- a/newdle/client/src/util/date.js
+++ b/newdle/client/src/util/date.js
@@ -18,7 +18,7 @@ export function overlaps([start1, end1], [start2, end2]) {
   return start1.isBefore(end2) && start2.isBefore(end1);
 }
 
-export function getHourSpan(input) {
+export function getHourSpan(input, shouldSpanTwoDays = true) {
   const {timeSlots, defaultHourSpan, defaultMinHour, defaultMaxHour, duration, format} = input;
   const timeSlotsMoment = timeSlots.map(c => toMoment(c, format));
   const minTimelineHour = Math.min(...timeSlotsMoment.map(timeSlot => timeSlot.hour()));
@@ -34,7 +34,7 @@ export function getHourSpan(input) {
       timeSlot => !timeSlot.isSame(timeSlot.clone().add(duration, 'm'), 'day')
     ) !== undefined;
   let maxTimelineHour;
-  if (spansOverTwoDays) {
+  if (spansOverTwoDays && shouldSpanTwoDays) {
     maxTimelineHour = 24 + maxTimeline.hour();
   } else {
     maxTimelineHour = maxTimeline.minutes() ? maxTimeline.hour() + 1 : maxTimeline.hour();


### PR DESCRIPTION
This issue resolves #490. Continues #494 PR.

1. When the timeline is clicked, a new slot with the default duration is added.
2. A tooltip is displayed on mouse hover to indicate the position in the timeline.
3. The granularity is set to 15 minutes, but it can be changed using the time picker.

https://github.com/user-attachments/assets/263ae6a0-4d8d-40ec-9d65-cc7462481874