### PR TITLE
exchange: Fix weird timezone error on latest Python

### DIFF
--- a/newdle/providers/free_busy/exchange.py
+++ b/newdle/providers/free_busy/exchange.py
@@ -117,8 +117,8 @@ def fetch_free_busy(date, tz, uid, email):
                 for event in busy_info.calendar_events or []:
                     overlap = find_overlap(
                         date,
-                        event.start.replace(tzinfo=account_tz),
-                        event.end.replace(tzinfo=account_tz),
+                        _ews_to_dt(event.start).replace(tzinfo=account_tz),
+                        _ews_to_dt(event.end).replace(tzinfo=account_tz),
                         tzinfo,
                     )
                     if event.busy_type in {'Busy', 'Tentative', 'OOF'} and overlap:
@@ -135,3 +135,14 @@ def fetch_free_busy(date, tz, uid, email):
     return [
         ((start.hour, start.minute), (end.hour, end.minute)) for start, end in results
     ]
+
+
+def _ews_to_dt(ews_dt):
+    return datetime(
+        ews_dt.year,
+        ews_dt.month,
+        ews_dt.day,
+        ews_dt.hour,
+        ews_dt.minute,
+        ews_dt.second,
+    )


### PR DESCRIPTION
See ecederstrand/exchangelib#1364 for details.

For the record, this is the original error that happened:

```py
Traceback (most recent call last):
  File "~/dev/newdle/.venv/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/.venv/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/.venv/lib/python3.12/site-packages/webargs/core.py", line 649, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/newdle/api.py", line 280, in get_participant_busy_times
    return _get_busy_times(date, tz, participant.auth_uid, participant.email)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/newdle/api.py", line 289, in _get_busy_times
    data += module.fetch_free_busy(date, tz, uid, email)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/newdle/providers/free_busy/exchange.py", line 118, in fetch_free_busy
    overlap = find_overlap(
              ^^^^^^^^^^^^^
  File "~/dev/newdle/newdle/core/util.py", line 90, in find_overlap
    tz.localize(datetime.combine(day, time.min)), start.astimezone(tz)
                                                  ^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/.venv/lib/python3.12/site-packages/exchangelib/ewsdatetime.py", line 128, in astimezone
    t = super().astimezone(tz=tz).replace(tzinfo=tz)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/.venv/lib/python3.12/site-packages/pytz/tzinfo.py", line 204, in fromutc
    return (dt + inf[0]).replace(tzinfo=self._tzinfos[inf])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/dev/newdle/.venv/lib/python3.12/site-packages/exchangelib/ewsdatetime.py", line 93, in __new__
    raise InvalidTypeError("tzinfo", tzinfo, EWSTimeZone)
exchangelib.errors.InvalidTypeError: 'tzinfo' <DstTzInfo 'Europe/Berlin' CEST+2:00:00 DST> must be of type <class 'exchangelib.ewsdatetime.EWSTimeZone'>
```
